### PR TITLE
Added ability to download recent video clip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ A list of changes between each release
 - Refactored code for better organization
 - Moved some request calls out of @property methods (enables future CLI support)
 - Renamed get_summary() method to summary and changed to @property
+- Added ability to download most recent video clip
 
 0.6.0 (2017-05-12)
 ^^^^^^^^^^^^^^^^^^

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -178,6 +178,13 @@ class BlinkCamera(object):
             with open(path, 'wb') as imgfile:
                 copyfileobj(response.raw, imgfile)
 
+    def video_to_file(self, path):
+        """Write video to file."""
+        response = _request(self.blink, url=self.clip, headers=self.header,
+                            reqtype='get', stream=True, json_resp=False)
+        with open(path, 'wb') as vidfile:
+            copyfileobj(response.raw, vidfile)
+
 
 class Blink(object):
     """Class to initialize communication and sync module."""


### PR DESCRIPTION
## Description:
Added method to download video clip:

```
BlinkCamera.video_to_file('/path/to/file.mp4')
```

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Tests added to verify new code works