### PR TITLE
Handle the armed status better

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ A list of changes between each release
 - Moved some request calls out of @property methods (enables future CLI support)
 - Renamed get_summary() method to summary and changed to @property
 - Added ability to download most recent video clip
+- Improved camera arm/disarm handling (`@b10m <https://github.com/fronzbot/blinkpy/pull/50>`_)
 
 0.6.0 (2017-05-12)
 ^^^^^^^^^^^^^^^^^^

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -97,7 +97,7 @@ class BlinkCamera(object):
         self.urls = self.blink.urls
         self.id = str(config['device_id'])  # pylint: disable=invalid-name
         self.name = config['name']
-        self._status = config['armed']
+        self._status = config['active']
         self.thumbnail = "{}{}.jpg".format(self.urls.base_url,
                                            config['thumbnail'])
         self.clip = "{}{}".format(self.urls.base_url, config['video'])
@@ -111,9 +111,14 @@ class BlinkCamera(object):
         self.region_id = config['region_id']
 
     @property
+    def status(self):
+        """Return camera status."""
+        return self._status
+
+    @property
     def armed(self):
         """Return camera arm status."""
-        return self._status
+        return True if self._status == 'armed' else False
 
     @property
     def battery_string(self):
@@ -143,7 +148,7 @@ class BlinkCamera(object):
     def update(self, values):
         """Update camera information."""
         self.name = values['name']
-        self._status = values['armed']
+        self._status = values['active']
         self.thumbnail = "{}{}.jpg".format(
             self.urls.base_url, values['thumbnail'])
         self.clip = "{}{}".format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-pytest>=2.9.2
-pytest-cov>=2.3.1
-pytest-timeout>=1.0.0
 requests>=2.12.4
 testtools

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,9 +2,9 @@ flake8==3.3
 flake8-docstrings==1.1.0
 pylint==1.8.1
 pydocstyle==2.0.0
-pytest>=2.9.2
+pytest==3.3.1
 pytest-cov>=2.3.1
-pytest-sugar>=0.8.0
+pytest-sugar>=0.9.0
 pytest-timeout>=1.0.0
 restructuredtext-lint>=1.0.1
 pygments>=2.2.0

--- a/tests/mock_responses.py
+++ b/tests/mock_responses.py
@@ -11,6 +11,7 @@ LOGIN_RESPONSE = {
             'name': 'TestNetwork',
             'account_id': 1111,
             'id': 2222,
+            'active': 'armed',
             'armed': True,
             'arm_string': 'Armed'
         }]

--- a/tests/test_blink_cameras.py
+++ b/tests/test_blink_cameras.py
@@ -27,6 +27,7 @@ class TestBlinkCameraSetup(unittest.TestCase):
             'device_id': 1111,
             'name': 'foobar',
             'armed': False,
+            'active': 'disarmed',
             'thumbnail': '/test/image',
             'video': '/test/clip/clip.mp4',
             'temp': 70,

--- a/tests/test_blink_cameras.py
+++ b/tests/test_blink_cameras.py
@@ -73,7 +73,7 @@ class TestBlinkCameraSetup(unittest.TestCase):
             self.assertEqual(camera.notifications, 2)
             self.assertEqual(camera.region_id, 'test')
         camera_config = self.camera_config
-        camera_config['armed'] = True
+        camera_config['active'] = 'armed'
         camera_config['thumbnail'] = '/test2/image'
         camera_config['video'] = '/test2/clip.mp4'
         camera_config['temp'] = 60

--- a/tests/test_blink_functions.py
+++ b/tests/test_blink_functions.py
@@ -27,6 +27,7 @@ class TestBlinkFunctions(unittest.TestCase):
             'device_id': 1111,
             'name': 'foobar',
             'armed': False,
+            'active': 'disabled',
             'thumbnail': '/test',
             'video': '/test.mp4',
             'temp': 80,


### PR DESCRIPTION
Blink allows users to arm/disarm individual cameras. This is pretty useful for inside and outside cameras, for instance.

The `armed` information in the JSON however, merely indicates whether the *system* is armed, not whether the camera itself is armed. This value, which is the same as `blink.arm`, does not indicate whether the camera has motion detection enabled.

In the JSON, the true status information lies in the 'active' key. The value can be *'armed', 'disarmed'* or *'disabled'*. I believe this field has a lot more value. Therefor I store the active state in `self._status` and return a boolean based on whether the camera is actually recording when motion is detected. I've also added the `status` property to obtain the real value.