### PR TITLE
Added authentication to login function and deprecated setup_system

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ A list of changes between each release
 - Renamed get_summary() method to summary and changed to @property
 - Added ability to download most recent video clip
 - Improved camera arm/disarm handling (`@b10m <https://github.com/fronzbot/blinkpy/pull/50>`_)
+- Added authentication to ``login()`` function and deprecated ``setup_system()`` in favor of ``start()``
 
 0.6.0 (2017-05-12)
 ^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -38,24 +38,16 @@ This library was built with the intention of allowing easy communication with Bl
 
 Usage
 =========
-In terms of usage, you just need to instantiate the module with a username and password and call the ``setup_system()`` method.
+The simplest way to use this package from a terminal is to call ``Blink.start()`` which will prompt for your Blink username and password and then log you in.  Alternatively, you can instantiate the Blink class with a username and password, and call ``Blink.start()`` to login and setup without prompt, as shown below.
 
 .. code:: python
 
     import blinkpy
     blink = blinkpy.Blink(username='YOUR USER NAME', password='YOUR PASSWORD')
-    blink.setup_system()
+    blink.start()
 
-If you leave out either of those parameters, you need to call the login function which will prompt for your username and password
+If you would like to log in without setting up the cameras or system, you can simply call the ``Blink.login()`` function which will prompt for a username and password and then authenticate with the server.  This is useful if you want to avoid use of the ``start()`` function which simply acts as a wrapper for more targeted API methods.
 
-.. code:: python
-
-    import blinkpy
-    blink = blinkpy.Blink()
-    blink.login()
-
-
-Once the login information is entered, you can run the `setup_system()` function which will attempt to authenticate with Blink servers using your username and password, obtain network ids, and create a list of cameras.
 The cameras are of a BlinkCamera class, of which the following parameters can be used (the code below creates a Blink object and iterates through each camera found)
 
 .. code:: python
@@ -63,7 +55,7 @@ The cameras are of a BlinkCamera class, of which the following parameters can be
     import blinkpy
     
     blink = blinkpy.Blink(username='YOUR USER NAME', password='YOUR PASSWORD')
-    blink.setup_system()
+    blink.start()
     
     for name, camera in blink.cameras.items():
         print(name)                  # Name of the camera

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -364,6 +364,14 @@ class Blink(object):
             camera.header = self._auth_header
 
     def setup_system(self):
+        """Legacy method support."""
+        _LOGGER.warning(
+            ("Blink.setup_system() will be deprecated in future release. "
+             "Please use Blink.start() instead.")
+        )
+        self.start()
+
+    def start(self):
         """
         Perform full system setup.
 
@@ -371,9 +379,10 @@ class Blink(object):
         Essentially this is just a wrapper function for ease of use.
         """
         if self._username is None or self._password is None:
-            raise BlinkAuthenticationException(ERROR.AUTHENTICATE)
+            self.login()
+        else:
+            self.get_auth_token()
 
-        self.get_auth_token()
         self.get_ids()
         self.get_videos()
         if self.video_count > 0:
@@ -385,6 +394,11 @@ class Blink(object):
         """Prompt user for username and password."""
         self._username = input("Username:")
         self._password = getpass.getpass("Password:")
+        if self.get_auth_token():
+            _LOGGER.info("Login successful!")
+            return True
+        _LOGGER.warning("Unable to login with %s.", self._username)
+        return False
 
     def get_auth_token(self):
         """Retrieve the authentication token from Blink."""

--- a/tests/test_blink_setup.py
+++ b/tests/test_blink_setup.py
@@ -40,8 +40,6 @@ class TestBlinkSetup(unittest.TestCase):
         """Check that we throw an exception when no username/password."""
         with self.assertRaises(blinkpy.BlinkAuthenticationException):
             self.blink_no_cred.get_auth_token()
-        with self.assertRaises(blinkpy.BlinkAuthenticationException):
-            self.blink_no_cred.setup_system()
         # pylint: disable=protected-access
         self.blink_no_cred._username = USERNAME
         with self.assertRaises(blinkpy.BlinkAuthenticationException):
@@ -58,12 +56,14 @@ class TestBlinkSetup(unittest.TestCase):
             # pylint: disable=protected-access
             self.blink._summary_request()
 
+    @mock.patch('blinkpy.blinkpy.requests.post',
+                side_effect=mresp.mocked_requests_post)
     @mock.patch('blinkpy.blinkpy.getpass.getpass')
-    def test_manual_login(self, getpwd):
+    def test_manual_login(self, getpwd, mock_post):
         """Check that we can manually use the login() function."""
         getpwd.return_value = PASSWORD
         with mock.patch('builtins.input', return_value=USERNAME):
-            self.blink_no_cred.login()
+            self.assertTrue(self.blink_no_cred.login())
         # pylint: disable=protected-access
         self.assertEqual(self.blink_no_cred._username, USERNAME)
         # pylint: disable=protected-access


### PR DESCRIPTION
## Description:
Moved auth to login to snd renamed `setup_system` to `start`.  `setup_system` can still be used, but will be deprecated some time in the future.

**Related issue (if applicable):** fixes #51

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] If user-facing functionality changed, README.rst updated
