### PR TITLE
Fix motion detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.pytest_cache/*
 .cache/*
 .tox/*
 __pycache__/*

--- a/tests/test_blink_cameras.py
+++ b/tests/test_blink_cameras.py
@@ -88,7 +88,7 @@ class TestBlinkCameraSetup(unittest.TestCase):
             self.assertEqual(camera.battery_string, "OK")
             self.assertEqual(camera.notifications, 2)
             self.assertEqual(camera.region_id, 'test')
-            self.assertEqual(camera.motion_detected, True)
+            self.assertEqual(camera.motion_enabled, True)
             self.assertEqual(camera.wifi_strength, -30)
 
         camera_config = self.camera_config
@@ -154,5 +154,5 @@ class TestBlinkCameraSetup(unittest.TestCase):
             self.assertEqual(camera_attr['battery'], 50)
             self.assertEqual(camera_attr['notifications'], 2)
             self.assertEqual(camera_attr['network_id'], '0000')
-            self.assertEqual(camera_attr['motion_detected'], True)
+            self.assertEqual(camera_attr['motion_enabled'], True)
             self.assertEqual(camera_attr['wifi_strength'], -30)


### PR DESCRIPTION
## Description:
- Use an array of recent video clips to determine if motion has been
detected.
- Reset the value every system refresh

The `motion_detected` attribute of each camera will act as a trigger, and will *not* stay high permanently.  The thought is that when motion is detected, it should trigger other actions external to the API (like notifcations in home-assistant) so the variable will return to `False` on a subsequent call to `blink.refresh()`


**Related issue (if applicable):** fixes #73 #75 

Still need to add tests for the new code before merging to the master branch

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ ] Tests added to verify new code works