### PR TITLE
Support multiple network_ids and avoid summary api call

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -24,7 +24,7 @@ class BlinkCamera():
                                            config['thumbnail'])
         self.clip = "{}/network/{}/camera/{}/clip".format(self.urls.base_url,config["network_id"], config["camera_id"])
         self.temperature = config['temperature']
-        self._battery_string = config['battery_state']
+        self._battery_string = config['battery_voltage']
         self.motion = dict()
         self.header = None
         self.image_link = None


### PR DESCRIPTION
## Description:

Current implementation lacks:
- Support for multiple network ids

This PR is incomplete, but starts the rework to support multiple network ids and move into a new API

More information https://github.com/MattTW/BlinkMonitorProtocol
**Related issue (if applicable):** fixes #90 

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ ] If user-facing functionality changed, README.rst updated
- [ ] Tests added to verify new code works