### PR TITLE
Reauth bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/*
 .sh
 build/*
 docs/_build
+*.log

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -21,7 +21,7 @@ from blinkpy.helpers.util import (
     create_session, BlinkURLHandler,
     BlinkAuthenticationException)
 from blinkpy.helpers.constants import (
-    BLINK_URL, LOGIN_URL, LOGIN_BACKUP_URL)
+    BLINK_URL, LOGIN_URL, LOGIN_BACKUP_URL, PROJECT_URL)
 
 REFRESH_RATE = 30
 
@@ -146,8 +146,7 @@ class Blink():
         if all_networks:
             _LOGGER.error(("More than one unboarded network. "
                            "Platform may not work as intended. "
-                           "Please open an issue on "
-                           "https://github.com/fronzbot/blinkpy."))
+                           "Please open an issue on %s"), PROJECT_URL)
 
     def refresh(self, force_cache=False):
         """

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -59,7 +59,13 @@ def http_req(blink, url='http://example.com', data=None, headers=None,
                                 reqtype=reqtype, stream=stream,
                                 json_resp=json_resp, is_retry=True)
     except (exceptions.ConnectionError, exceptions.Timeout):
-        _LOGGER.error("Cannot connect to server. Possible outage.")
+        _LOGGER.error("Cannot connect to server with url %s.", url)
+        if not is_retry:
+            headers = attempt_reauthorization(blink)
+            return http_req(blink, url=url, data=data, headers=headers,
+                            reqtype=reqtype, stream=stream,
+                            json_resp=json_resp, is_retry=True)
+        _LOGGER.error("Possible issue with Blink servers.")
         return None
 
     if json_resp:

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -14,6 +14,7 @@ from blinkpy.sync_module import BlinkSyncModule
 from blinkpy.helpers.util import (
     http_req, create_session, BlinkAuthenticationException,
     BlinkException, BlinkURLHandler)
+from blinkpy.helpers.constants import PROJECT_URL
 import tests.mock_responses as mresp
 
 USERNAME = 'foobar'
@@ -77,11 +78,15 @@ class TestBlinkSetup(unittest.TestCase):
     def test_bad_request(self, mock_sess):
         """Check that we raise an Exception with a bad request."""
         self.blink.session = create_session()
+        explog = ("ERROR:blinkpy.helpers.util:"
+                  "Cannot obtain new token for server auth. "
+                  "Please report this issue on {}").format(PROJECT_URL)
         with self.assertRaises(BlinkException):
             http_req(self.blink, reqtype='bad')
 
-        with self.assertRaises(BlinkAuthenticationException):
+        with self.assertLogs() as logrecord:
             http_req(self.blink, reqtype='post', is_retry=True)
+        self.assertEqual(logrecord.output, [explog])
 
     def test_authentication(self, mock_sess):
         """Check that we can authenticate Blink up properly."""


### PR DESCRIPTION
## Description:
Attempt re-authorization even if `ConnectionError` or `Timeout` are thrown.

**Related issue (if applicable):** fixes #101 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
