### PR TITLE
Changed 'warning' to 'info' in camera

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -162,8 +162,8 @@ class BlinkCamera():
             else:
                 self.motion_detected = False
         except KeyError:
-            _LOGGER.warning("Could not extract clip info from camera %s",
-                            self.name)
+            _LOGGER.info("Could not extract clip info from camera %s",
+                         self.name)
 
     def image_to_file(self, path):
         """
@@ -187,6 +187,9 @@ class BlinkCamera():
         """
         _LOGGER.debug("Writing video from %s to %s", self.name, path)
         response = self._cached_video
+        if response is None:
+            _LOGGER.error("No saved video exist for %s.", self.name)
+            return
         with open(path, 'wb') as vidfile:
             copyfileobj(response.raw, vidfile)
 


### PR DESCRIPTION
## Description:
Write to log as 'info' rather than 'warning' if a video isn't on the server.

**Related issue (if applicable):** fixes #102

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
