### PR TITLE
Reformatted log message when multiple networks detected.

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -144,9 +144,10 @@ class Blink():
             if str(resp['id']) == self.network_id:
                 self.account_id = resp['account_id']
         if all_networks:
-            _LOGGER.error(("More than one unboarded network. "
-                           "Platform may not work as intended. "
-                           "Please open an issue on %s"), PROJECT_URL)
+            _LOGGER.warning(("More than one onboarded network. "
+                             "Platform may not work as intended. "
+                             "If you experience problems, please "
+                             "open an issue on {}".format(PROJECT_URL)))
 
     def refresh(self, force_cache=False):
         """

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -147,7 +147,7 @@ class Blink():
             _LOGGER.warning(("More than one onboarded network. "
                              "Platform may not work as intended. "
                              "If you experience problems, please "
-                             "open an issue on {}".format(PROJECT_URL)))
+                             "open an issue on %s"), PROJECT_URL)
 
     def refresh(self, force_cache=False):
         """


### PR DESCRIPTION
## Description:
- "unboarded" changed to "onboarded
- Changed multi-network error to warning

**Related issue (if applicable):** fixes #108 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
