### PR TITLE
0.10.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changelog
 
 A list of changes between each release
 
+0.10.1 (2018-10-18)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Fix re-authorization bug (fixes `#101 <https://github.com/fronzbot/blinkpy/issues/#101>`_)
+- Log an error if saving video that doesn't exist
+
 0.10.0 (2018-10-16)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Moved all API calls to own module for easier maintainability

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 blinkpy |Build Status| |Coverage Status| |Docs| |PyPi Version| |Python Version|
-================================================================
+================================================================================
 A Python library for the Blink Camera system
 Only compatible with Python 3+
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-blinkpy |Build Status| |Coverage Status| |Docs|  |PyPi Version|
+blinkpy |Build Status| |Coverage Status| |Docs| |PyPi Version| |Python Version|
 ================================================================
 A Python library for the Blink Camera system
 Only compatible with Python 3+
@@ -90,3 +90,5 @@ The ``blinkpy`` api also allows for saving images and videos to a file and snapp
     :target: https://pypi.python.org/pypi/blinkpy
 .. |Docs| image:: https://readthedocs.org/projects/blinkpy/badge/?version=latest
    :target: http://blinkpy.readthedocs.io/en/latest/?badge=latest
+.. |Python Version| image:: https://img.shields.io/pypi/pyversions/blinkpy.svg
+   :target: https://img.shields.io/pypi/pyversions/blinkpy.svg

--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -4,7 +4,7 @@ import os
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 10
-PATCH_VERSION = 0
+PATCH_VERSION = 1
 
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 

--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -3,8 +3,8 @@
 import os
 
 MAJOR_VERSION = 0
-MINOR_VERSION = 10
-PATCH_VERSION = 1
+MINOR_VERSION = 11
+PATCH_VERSION = '0.dev'
 
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 


### PR DESCRIPTION
## Description:
- Set minimum required version of `requests` to 2.20.0 due to vulnerability in earlier releases
- Change multi-network log level to `warning` instead of `error`

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended

