### PR TITLE
Use network_status instead of homescreen

### DIFF
--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -89,8 +89,7 @@ class BlinkSyncModule():
 
         self.homescreen = api.request_homescreen(self.blink)
 
-        self.network_info = api.request_network_status(self.blink, 
-                                                       self.network_id)
+        self.network_info = api.request_network_status(self.blink, self.network_id)
 
         camera_info = self.get_camera_info()
         for camera_config in camera_info:
@@ -118,8 +117,7 @@ class BlinkSyncModule():
         self.events = self.get_events()
         self.videos = self.get_videos()
         self.homescreen = api.request_homescreen(self.blink)
-        self.network_info = api.request_network_status(self.blink, 
-                                                       self.network_id)
+        self.network_info = api.request_network_status(self.blink, self.network_id)
         camera_info = self.get_camera_info()
         for camera_config in camera_info:
             name = camera_config['name']

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -89,7 +89,8 @@ class BlinkSyncModule():
 
         self.homescreen = api.request_homescreen(self.blink)
 
-        self.network_info = api.request_network_status(self.blink, self.network_id)
+        self.network_info = api.request_network_status(self.blink,
+                                                       self.network_id)
 
         camera_info = self.get_camera_info()
         for camera_config in camera_info:

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -31,6 +31,7 @@ class BlinkSyncModule():
         self.host = None
         self.summary = None
         self.homescreen = None
+        self.network_info = None
         self.record_dates = {}
         self.videos = {}
         self.events = []
@@ -64,7 +65,7 @@ class BlinkSyncModule():
     @property
     def arm(self):
         """Return status of sync module: armed/disarmed."""
-        return self.homescreen['network']['armed']
+        return self.network_info['network']['armed']
 
     @arm.setter
     def arm(self, value):
@@ -87,6 +88,8 @@ class BlinkSyncModule():
         self.events = self.get_events()
 
         self.homescreen = api.request_homescreen(self.blink)
+
+        self.network_info = api.request_network_status(self.blink,self.network_id)
 
         camera_info = self.get_camera_info()
         for camera_config in camera_info:
@@ -114,6 +117,7 @@ class BlinkSyncModule():
         self.events = self.get_events()
         self.videos = self.get_videos()
         self.homescreen = api.request_homescreen(self.blink)
+        self.network_info = api.request_network_status(self.blink,self.network_id)
         camera_info = self.get_camera_info()
         for camera_config in camera_info:
             name = camera_config['name']

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -89,7 +89,8 @@ class BlinkSyncModule():
 
         self.homescreen = api.request_homescreen(self.blink)
 
-        self.network_info = api.request_network_status(self.blink,self.network_id)
+        self.network_info = api.request_network_status(self.blink, 
+                                                       self.network_id)
 
         camera_info = self.get_camera_info()
         for camera_config in camera_info:
@@ -117,7 +118,8 @@ class BlinkSyncModule():
         self.events = self.get_events()
         self.videos = self.get_videos()
         self.homescreen = api.request_homescreen(self.blink)
-        self.network_info = api.request_network_status(self.blink,self.network_id)
+        self.network_info = api.request_network_status(self.blink, 
+                                                       self.network_id)
         camera_info = self.get_camera_info()
         for camera_config in camera_info:
             name = camera_config['name']

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -118,7 +118,8 @@ class BlinkSyncModule():
         self.events = self.get_events()
         self.videos = self.get_videos()
         self.homescreen = api.request_homescreen(self.blink)
-        self.network_info = api.request_network_status(self.blink, self.network_id)
+        self.network_info = api.request_network_status(self.blink,
+                                                       self.network_id)
         camera_info = self.get_camera_info()
         for camera_config in camera_info:
             name = camera_config['name']

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -88,8 +88,8 @@ class TestBlinkSyncModule(unittest.TestCase):
                 'status': 'foobar'}},
             {'event': True},
             {},
+            {},
             {'devicestatus': {}},
-            None,
             None,
             None
         ]

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -90,6 +90,7 @@ class TestBlinkSyncModule(unittest.TestCase):
             {},
             {'devicestatus': {}},
             None,
+            None,
             None
         ]
         self.blink.sync.start()


### PR DESCRIPTION
Use network_status to check if System is armed or disarmed

## Description:


**Related issue (if applicable):** fixes #<blinkpy issue number goes here>
fixes #118 

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ ] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
