### PR TITLE
Add calibrated temperature property (fixes #133)

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -24,6 +24,7 @@ class BlinkCamera():
         self.battery_voltage = None
         self.clip = None
         self.temperature = None
+        self.temperature_calibrated = None
         self.battery_state = None
         self.motion_detected = None
         self.wifi_strength = None
@@ -40,6 +41,7 @@ class BlinkCamera():
             'serial': self.serial,
             'temperature': self.temperature,
             'temperature_c': self.temperature_c,
+            'temperature_calibrated': self.temperature_calibrated,
             'battery': self.battery,
             'thumbnail': self.thumbnail,
             'video': self.clip,
@@ -103,6 +105,15 @@ class BlinkCamera():
         self.battery_state = config['battery_state']
         self.temperature = config['temperature']
         self.wifi_strength = config['wifi_strength']
+
+        # Retrieve calibrated temperature from special endpoint
+        resp = api.request_camera_sensors(self.sync.blink,
+                                          self.network_id,
+                                          self.camera_id)
+        try:
+            self.temperature_calibrated = resp['temp']
+        except KeyError:
+            _LOGGER.error("Could not retrieve calibrated temperature.")
 
         # Check if thumbnail exists in config, if not try to
         # get it from the homescreen info in teh sync module

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -98,6 +98,7 @@ class TestBlinkCameraSetup(unittest.TestCase):
         self.camera.last_record = ['1']
         self.camera.sync.all_clips = {'new': {'1': '/test.mp4'}}
         mock_sess.side_effect = [
+            mresp.MockResponse({'temp': 71}, 200),
             'test',
             'foobar'
         ]
@@ -110,6 +111,7 @@ class TestBlinkCameraSetup(unittest.TestCase):
         self.assertEqual(self.camera.battery, 50)
         self.assertEqual(self.camera.temperature, 68)
         self.assertEqual(self.camera.temperature_c, 20)
+        self.assertEqual(self.camera.temperature_calibrated, 71)
         self.assertEqual(self.camera.wifi_strength, 4)
         self.assertEqual(self.camera.thumbnail,
                          'https://rest.test.immedia-semi.com/thumb.jpg')
@@ -120,7 +122,11 @@ class TestBlinkCameraSetup(unittest.TestCase):
 
     def test_thumbnail_not_in_info(self, mock_sess):
         """Test that we grab thumbanil if not in camera_info."""
-        mock_sess.side_effect = ['foobar', 'barfoo']
+        mock_sess.side_effect = [
+            mresp.MockResponse({'temp': 71}, 200),
+            'foobar',
+            'barfoo'
+        ]
         self.camera.last_record = ['1']
         self.camera.sync.record_dates['new'] = ['1']
         self.camera.sync.all_clips = {'new': {'1': '/test.mp4'}}
@@ -175,7 +181,8 @@ class TestBlinkCameraSetup(unittest.TestCase):
         self.assertEqual(self.camera.thumbnail, None)
         self.assertEqual(
             logrecord.output,
-            ["ERROR:blinkpy.camera:Could not find thumbnail for camera new"]
+            ["ERROR:blinkpy.camera:Could not retrieve calibrated temperature.",
+             "ERROR:blinkpy.camera:Could not find thumbnail for camera new"]
         )
 
     def test_no_video_clips(self, mock_sess):


### PR DESCRIPTION
## Description:
Adds `temperature_calibrated` property to cameras.  The endpoint for this property is different than all other camera info.  The default camera info endpoints only return the raw, un-calibrated, temperature for some reason.

**Related issue (if applicable):** fixes #133

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
