### PR TITLE
Add repeat log handling filter.

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -111,7 +111,7 @@ class BlinkCamera():
         try:
             self.temperature_calibrated = resp['temp']
         except KeyError:
-            _LOGGER.error("Could not retrieve calibrated temperature.")
+            _LOGGER.warning("Could not retrieve calibrated temperature.")
 
         # Check if thumbnail exists in config, if not try to
         # get it from the homescreen info in teh sync module
@@ -172,7 +172,8 @@ class BlinkCamera():
                 copyfileobj(response.raw, imgfile)
         else:
             _LOGGER.error("Cannot write image to file, response %s",
-                          response.status_code)
+                          response.status_code,
+                          exc_info=True)
 
     def video_to_file(self, path):
         """Write video to file.
@@ -182,7 +183,9 @@ class BlinkCamera():
         _LOGGER.debug("Writing video from %s to %s", self.name, path)
         response = self._cached_video
         if response is None:
-            _LOGGER.error("No saved video exist for %s.", self.name)
+            _LOGGER.error("No saved video exist for %s.",
+                          self.name,
+                          exc_info=True)
             return
         with open(path, 'wb') as vidfile:
             copyfileobj(response.raw, vidfile)
@@ -198,5 +201,7 @@ class BlinkCamera():
                     return device_thumb
             except KeyError:
                 pass
-        _LOGGER.error("Could not find thumbnail for camera %s", self.name)
+        _LOGGER.error("Could not find thumbnail for camera %s",
+                      self.name,
+                      exc_info=True)
         return None

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -121,3 +121,18 @@ class BlinkURLHandler():
         self.networks_url = "{}/networks".format(self.base_url)
         self.video_url = "{}/api/v2/videos".format(self.base_url)
         _LOGGER.debug("Setting base url to %s.", self.base_url)
+
+
+class RepeatLogHandler(logging.StreamHandler):
+    """Log handler for repeat entries."""
+
+    def __init__(self):
+        """Initialize repeat log handler."""
+        super().__init__()
+        self.log_record = set()
+
+    def emit(self, record):
+        """Ensure we only log a message once."""
+        if record.msg not in self.log_record:
+            self.log_record.add(record.msg)
+            super().emit(record)

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -82,7 +82,7 @@ class BlinkSyncModule():
             self.network_id = self.summary['network_id']
         except (TypeError, KeyError):
             _LOGGER.error(("Could not retrieve sync module information "
-                           "with response: %s"), response)
+                           "with response: %s"), response, exc_info=True)
             return False
 
         try:
@@ -91,7 +91,8 @@ class BlinkSyncModule():
             self.status = self.summary['status']
         except KeyError:
             _LOGGER.error("Could not extract some sync module info: %s",
-                          response)
+                          response,
+                          exc_info=True)
 
         self.events = self.get_events()
         self.homescreen = api.request_homescreen(self.blink)
@@ -114,7 +115,9 @@ class BlinkSyncModule():
         try:
             return response['event']
         except (TypeError, KeyError):
-            _LOGGER.error("Could not extract events: %s", response)
+            _LOGGER.error("Could not extract events: %s",
+                          response,
+                          exc_info=True)
             return False
 
     def get_camera_info(self):
@@ -123,7 +126,9 @@ class BlinkSyncModule():
         try:
             return response['devicestatus']
         except (TypeError, KeyError):
-            _LOGGER.error("Could not extract camera info: %s", response)
+            _LOGGER.error("Could not extract camera info: %s",
+                          response,
+                          exc_info=True)
             return []
 
     def refresh(self, force_cache=False):

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -163,8 +163,10 @@ class TestBlinkCameraSetup(unittest.TestCase):
         self.assertEqual(self.camera.last_record, ['1'])
         self.assertEqual(
             logrecord.output,
-            ["ERROR:blinkpy.camera:Could not retrieve calibrated temperature.",
-             "ERROR:blinkpy.camera:Could not find thumbnail for camera new"]
+            [("WARNING:blinkpy.camera:Could not retrieve calibrated "
+              "temperature."),
+             ("ERROR:blinkpy.camera:Could not find thumbnail for camera new"
+              "\nNoneType: None")]
         )
 
     def test_no_video_clips(self, mock_sess):


### PR DESCRIPTION
- Added exc_info=True to some errors for traceback logging

## Description:
Adds a handler that gets removed and reset upon successive calls to `Blink.start()`.  This handler has a filter that will suppress the same log message from being written more than once.

**Related issue (if applicable):** fixes #142 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended