### PR TITLE
Set calibrated temperature to default to temperature if endpoint fails

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -111,6 +111,7 @@ class BlinkCamera():
         try:
             self.temperature_calibrated = resp['temp']
         except KeyError:
+            self.temperature_calibrated = self.temperature
             _LOGGER.error("Could not retrieve calibrated temperature.")
 
         # Check if thumbnail exists in config, if not try to

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -157,10 +157,12 @@ class TestBlinkCameraSetup(unittest.TestCase):
         self.camera.sync.homescreen = {
             'devices': []
         }
+        self.assertEqual(self.camera.temperature_calibrated, None)
         with self.assertLogs() as logrecord:
             self.camera.update(config)
         self.assertEqual(self.camera.thumbnail, None)
         self.assertEqual(self.camera.last_record, ['1'])
+        self.assertEqual(self.camera.temperature_calibrated, 68)
         self.assertEqual(
             logrecord.output,
             ["ERROR:blinkpy.camera:Could not retrieve calibrated temperature.",


### PR DESCRIPTION
## Description:
If calibrated temp endpoint fails for some reason, we should set this value to the raw temperature as a backup.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
