### PR TITLE
Added throttles to api calls

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -3,10 +3,12 @@
 import logging
 from json import dumps
 import blinkpy.helpers.errors as ERROR
-from blinkpy.helpers.util import http_req, get_time, BlinkException
+from blinkpy.helpers.util import http_req, get_time, BlinkException, Throttle
 from blinkpy.helpers.constants import DEFAULT_URL
 
 _LOGGER = logging.getLogger(__name__)
+
+MIN_THROTTLE_TIME = 4
 
 
 def request_login(blink, url, username, password, is_retry=False):
@@ -38,6 +40,7 @@ def request_networks(blink):
     return http_get(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_network_status(blink, network):
     """
     Request network information.
@@ -49,6 +52,7 @@ def request_network_status(blink, network):
     return http_get(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_syncmodule(blink, network):
     """
     Request sync module info.
@@ -60,6 +64,7 @@ def request_syncmodule(blink, network):
     return http_get(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_system_arm(blink, network):
     """
     Arm system.
@@ -71,6 +76,7 @@ def request_system_arm(blink, network):
     return http_post(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_system_disarm(blink, network):
     """
     Disarm system.
@@ -102,6 +108,7 @@ def request_homescreen(blink):
     return http_get(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_sync_events(blink, network):
     """
     Request events from sync module.
@@ -113,6 +120,7 @@ def request_sync_events(blink, network):
     return http_get(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_new_image(blink, network, camera_id):
     """
     Request to capture new thumbnail for camera.
@@ -127,6 +135,7 @@ def request_new_image(blink, network, camera_id):
     return http_post(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_new_video(blink, network, camera_id):
     """
     Request to capture new video clip.
@@ -141,6 +150,7 @@ def request_new_video(blink, network, camera_id):
     return http_post(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_video_count(blink):
     """Request total video count."""
     url = "{}/api/v2/videos/count".format(blink.urls.base_url)
@@ -161,6 +171,7 @@ def request_videos(blink, time=None, page=0):
     return http_get(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_cameras(blink, network):
     """
     Request all camera information.
@@ -172,6 +183,7 @@ def request_cameras(blink, network):
     return http_get(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_camera_info(blink, network, camera_id):
     """
     Request camera info for one camera.
@@ -186,6 +198,7 @@ def request_camera_info(blink, network, camera_id):
     return http_get(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_camera_sensors(blink, network, camera_id):
     """
     Request camera sensor info for one camera.
@@ -200,6 +213,7 @@ def request_camera_sensors(blink, network, camera_id):
     return http_get(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_motion_detection_enable(blink, network, camera_id):
     """
     Enable motion detection for a camera.
@@ -214,6 +228,7 @@ def request_motion_detection_enable(blink, network, camera_id):
     return http_post(blink, url)
 
 
+@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_motion_detection_disable(blink, network, camera_id):
     """Disable motion detection for a camera.
 

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -92,8 +92,9 @@ class BlinkCamera():
                                                     self.network_id,
                                                     self.camera_id)
 
-    def update(self, config, force_cache=False):
+    def update(self, config, force_cache=False, **kwargs):
         """Update camera info."""
+        force = kwargs.pop('force', False)
         self.name = config['name']
         self.camera_id = str(config['camera_id'])
         self.network_id = str(config['network_id'])
@@ -107,12 +108,15 @@ class BlinkCamera():
         # Retrieve calibrated temperature from special endpoint
         resp = api.request_camera_sensors(self.sync.blink,
                                           self.network_id,
-                                          self.camera_id)
+                                          self.camera_id,
+                                          force=force)
         try:
             self.temperature_calibrated = resp['temp']
         except KeyError:
             self.temperature_calibrated = self.temperature
             _LOGGER.warning("Could not retrieve calibrated temperature.")
+        except TypeError:
+            _LOGGER.debug("API call temporarily throttled.")
 
         # Check if thumbnail exists in config, if not try to
         # get it from the homescreen info in teh sync module

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -76,7 +76,9 @@ class BlinkSyncModule():
 
     def start(self):
         """Initialize the system."""
-        response = api.request_syncmodule(self.blink, self.network_id)
+        response = api.request_syncmodule(self.blink,
+                                          self.network_id,
+                                          force=True)
         try:
             self.summary = response['syncmodule']
             self.network_id = self.summary['network_id']
@@ -94,7 +96,7 @@ class BlinkSyncModule():
                           response,
                           exc_info=True)
 
-        self.events = self.get_events()
+        self.events = self.get_events(force=True)
         self.homescreen = api.request_homescreen(self.blink)
         self.network_info = api.request_network_status(self.blink,
                                                        self.network_id)
@@ -105,13 +107,18 @@ class BlinkSyncModule():
             name = camera_config['name']
             self.cameras[name] = BlinkCamera(self)
             self.motion[name] = False
-            self.cameras[name].update(camera_config, force_cache=True)
+            self.cameras[name].update(camera_config,
+                                      force_cache=True,
+                                      force=True)
 
         return True
 
-    def get_events(self):
+    def get_events(self, **kwargs):
         """Retrieve events from server."""
-        response = api.request_sync_events(self.blink, self.network_id)
+        force = kwargs.pop('force', False)
+        response = api.request_sync_events(self.blink,
+                                           self.network_id,
+                                           force=force)
         try:
             return response['event']
         except (TypeError, KeyError):
@@ -120,9 +127,12 @@ class BlinkSyncModule():
                           exc_info=True)
             return False
 
-    def get_camera_info(self):
+    def get_camera_info(self, **kwargs):
         """Retrieve camera information."""
-        response = api.request_cameras(self.blink, self.network_id)
+        force = kwargs.pop('force', False)
+        response = api.request_cameras(self.blink,
+                                       self.network_id,
+                                       force=force)
         try:
             return response['devicestatus']
         except (TypeError, KeyError):

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -159,7 +159,7 @@ class TestBlinkCameraSetup(unittest.TestCase):
         }
         self.assertEqual(self.camera.temperature_calibrated, None)
         with self.assertLogs() as logrecord:
-            self.camera.update(config)
+            self.camera.update(config, force=True)
         self.assertEqual(self.camera.thumbnail, None)
         self.assertEqual(self.camera.last_record, ['1'])
         self.assertEqual(self.camera.temperature_calibrated, 68)


### PR DESCRIPTION
## Description:
Adds throttle decorator to a bunch of api calls to prevent accidentally calling them in rapid succession.  I set the throttle time to 4 seconds so that any delay of 5 seconds in an individual's script will allow for uninterrupted accessing of data.

**API calls throttled**:
- request_network_status
- request_syncmodule
- request_system_arm
- request_system_disarm
- request_sync_events
- request_new_image
- request_new_video
- request_video_count
- request_cameras
- request_camera_info
- request_camera_sensors
- request_motion_detection_enable
- request_motion_detection_disable

In order to manually override the throttle, the argument `force=True` can be added to any api call and this will ignore the throttle.

For example, to ignore the throttle when requesting network status:

```python
blinkpy.api.request_network_status(blink, sync_network_id, force=True)
```

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
