### PR TITLE
Throttle refresh

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -8,7 +8,7 @@ from blinkpy.helpers.constants import DEFAULT_URL
 
 _LOGGER = logging.getLogger(__name__)
 
-MIN_THROTTLE_TIME = 4
+MIN_THROTTLE_TIME = 2
 
 
 def request_login(blink, url, username, password, is_retry=False):


### PR DESCRIPTION
## Description:
Adds throttle decorator to refresh function to prevent too many frequent calls with `force_cache` flag set to `True`.  This additional throttle can be overridden with the `force=True` argument passed to the refresh function.

**Related issue (if applicable):** fixes #155

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
