### PR TITLE
Added ability to have multiple backup api endpoints for logging in

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -29,7 +29,7 @@ from blinkpy.helpers.util import (
     create_session, merge_dicts, get_time, BlinkURLHandler,
     BlinkAuthenticationException)
 from blinkpy.helpers.constants import (
-    BLINK_URL, LOGIN_URL, LOGIN_BACKUP_URL)
+    BLINK_URL, LOGIN_URL, OLD_LOGIN_URL, LOGIN_BACKUP_URL)
 from blinkpy.helpers.constants import __version__
 
 REFRESH_RATE = 30
@@ -119,33 +119,12 @@ class Blink():
         if not isinstance(self._password, str):
             raise BlinkAuthenticationException(ERROR.PASSWORD)
 
-        login_url = LOGIN_URL
-        response = api.request_login(self,
-                                     login_url,
-                                     self._username,
-                                     self._password,
-                                     is_retry=is_retry)
-        try:
-            if response.status_code != 200:
-                _LOGGER.debug("Received response code %s during login.",
-                              response.status_code)
-                login_url = LOGIN_BACKUP_URL
-                response = api.request_login(self,
-                                             login_url,
-                                             self._username,
-                                             self._password,
-                                             is_retry=is_retry)
-            response = response.json()
-            (self.region_id, self.region), = response['region'].items()
-        except AttributeError:
-            _LOGGER.error("Login API endpoint failed with response %s",
-                          response,
-                          exc_info=True)
+        login_urls = [LOGIN_URL, OLD_LOGIN_URL, LOGIN_BACKUP_URL]
+
+        response = self.login_request(login_urls, is_retry=is_retry)
+
+        if not response:
             return False
-        except KeyError:
-            _LOGGER.warning("Could not extract region info.")
-            self.region_id = 'piri'
-            self.region = 'UNKNOWN'
 
         self._host = "{}.{}".format(self.region_id, BLINK_URL)
         self._token = response['authtoken']['authtoken']
@@ -154,9 +133,43 @@ class Blink():
         self._auth_header = {'Host': self._host,
                              'TOKEN_AUTH': self._token}
         self.urls = BlinkURLHandler(self.region_id)
-        self._login_url = login_url
 
         return self._auth_header
+
+    def login_request(self, login_urls, is_retry=False):
+        """Make a login request."""
+        try:
+            login_url = login_urls.pop(0)
+        except IndexError:
+            _LOGGER.error("Could not login to blink servers.")
+            return False
+
+        _LOGGER.info("Attempting login with %s", login_url)
+
+        response = api.request_login(self,
+                                     login_url,
+                                     self._username,
+                                     self._password,
+                                     is_retry=is_retry)
+        try:
+            if response.status_code != 200:
+                response = self.login_request(login_urls)
+            response = response.json()
+            (self.region_id, self.region), = response['region'].items()
+
+        except AttributeError:
+            _LOGGER.error("Login API endpoint failed with response %s",
+                          response,
+                          exc_info=True)
+            return False
+
+        except KeyError:
+            _LOGGER.warning("Could not extract region info.")
+            self.region_id = 'piri'
+            self.region = 'UNKNOWN'
+
+        self._login_url = login_url
+        return response
 
     def get_ids(self):
         """Set the network ID and Account ID."""

--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -47,7 +47,8 @@ URLS
 BLINK_URL = 'immedia-semi.com'
 DEFAULT_URL = "{}.{}".format('prod', BLINK_URL)
 BASE_URL = "https://{}".format(DEFAULT_URL)
-LOGIN_URL = "{}/login".format(BASE_URL)
+LOGIN_URL = "{}/api/v2/login".format(BASE_URL)
+OLD_LOGIN_URL = "{}/login".format(BASE_URL)
 LOGIN_BACKUP_URL = "https://{}.{}/login".format('rest.piri', BLINK_URL)
 
 '''


### PR DESCRIPTION
## Description:
There's a new login endpoint, but I don't want to remove the current one (since it's working) so I have a recursive routine that now can accept any number of urls and only fails once all options are exhausted.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
