### PR TITLE
Remove throttle from network_status

### DIFF
--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -3,8 +3,8 @@
 import os
 
 MAJOR_VERSION = 0
-MINOR_VERSION = 14
-PATCH_VERSION = '0.dev0'
+MINOR_VERSION = 13
+PATCH_VERSION = '1.dev0'
 
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -64,7 +64,10 @@ class BlinkSyncModule():
     @property
     def arm(self):
         """Return status of sync module: armed/disarmed."""
-        return self.network_info['network']['armed']
+        try:
+            return self.network_info['network']['armed']
+        except (KeyError, TypeError):
+            return None
 
     @arm.setter
     def arm(self, value):


### PR DESCRIPTION
## Description:
Throttle on network status was causing issues with checking for sync arm/disarm status (only within home-assistant, so it wasn't caught on local testing)

