### PR TITLE
Remove throttling from critical api methods

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -40,7 +40,6 @@ def request_networks(blink):
     return http_get(blink, url)
 
 
-@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_network_status(blink, network):
     """
     Request network information.
@@ -52,7 +51,6 @@ def request_network_status(blink, network):
     return http_get(blink, url)
 
 
-@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_syncmodule(blink, network):
     """
     Request sync module info.
@@ -173,7 +171,6 @@ def request_videos(blink, time=None, page=0):
     return http_get(blink, url)
 
 
-@Throttle(seconds=MIN_THROTTLE_TIME)
 def request_cameras(blink, network):
     """
     Request all camera information.

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -80,8 +80,7 @@ class BlinkSyncModule():
     def start(self):
         """Initialize the system."""
         response = api.request_syncmodule(self.blink,
-                                          self.network_id,
-                                          force=True)
+                                          self.network_id)
         try:
             self.summary = response['syncmodule']
             self.network_id = self.summary['network_id']


### PR DESCRIPTION
## Description:
Removed some aggressive throttling which was preventing multiple sync modules from reporting status properly (such as arm/disarm).  See [https://github.com/home-assistant/home-assistant/issues/22119](https://github.com/home-assistant/home-assistant/issues/22119).

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
