### PR TITLE
Change battery percentage to state

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -41,6 +41,7 @@ class BlinkCamera():
             'temperature_c': self.temperature_c,
             'temperature_calibrated': self.temperature_calibrated,
             'battery': self.battery,
+            'battery_voltage': self.battery_voltage,
             'thumbnail': self.thumbnail,
             'video': self.clip,
             'motion_enabled': self.motion_enabled,
@@ -54,8 +55,8 @@ class BlinkCamera():
 
     @property
     def battery(self):
-        """Return battery level as percentage."""
-        return round(self.battery_voltage / 180 * 100)
+        """Return battery as string."""
+        return self.battery_state
 
     @property
     def temperature_c(self):

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -87,7 +87,7 @@ class TestBlinkCameraSetup(unittest.TestCase):
         self.assertEqual(self.camera.network_id, '5678')
         self.assertEqual(self.camera.serial, '12345678')
         self.assertEqual(self.camera.motion_enabled, False)
-        self.assertEqual(self.camera.battery, 50)
+        self.assertEqual(self.camera.battery, 'ok')
         self.assertEqual(self.camera.temperature, 68)
         self.assertEqual(self.camera.temperature_c, 20)
         self.assertEqual(self.camera.temperature_calibrated, 71)


### PR DESCRIPTION
## Description:
Changes battery reporting to a state ('ok', 'replace', etc). Battery voltage is now accessible in camera attributes

**Related issue (if applicable):** fixes #166 
## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended

