### PR TITLE
Upgraded login urls to use rest-region subdomain

### DIFF
--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -3,8 +3,8 @@
 import os
 
 MAJOR_VERSION = 0
-MINOR_VERSION = 14
-PATCH_VERSION = '1.dev0'
+MINOR_VERSION = 15
+PATCH_VERSION = '0.dev0'
 
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 

--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -3,8 +3,8 @@
 import os
 
 MAJOR_VERSION = 0
-MINOR_VERSION = 15
-PATCH_VERSION = '0.dev0'
+MINOR_VERSION = 14
+PATCH_VERSION = '1.dev0'
 
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 
@@ -45,11 +45,11 @@ PYPI_URL = 'https://pypi.python.org/pypi/{}'.format(PROJECT_PACKAGE_NAME)
 URLS
 '''
 BLINK_URL = 'immedia-semi.com'
-DEFAULT_URL = "{}.{}".format('prod', BLINK_URL)
+DEFAULT_URL = "{}.{}".format('rest-prod', BLINK_URL)
 BASE_URL = "https://{}".format(DEFAULT_URL)
 LOGIN_URL = "{}/api/v2/login".format(BASE_URL)
 OLD_LOGIN_URL = "{}/login".format(BASE_URL)
-LOGIN_BACKUP_URL = "https://{}.{}/login".format('rest.piri', BLINK_URL)
+LOGIN_BACKUP_URL = "https://{}.{}/login".format('rest-piri', BLINK_URL)
 
 '''
 Dictionaries


### PR DESCRIPTION
## Description:
Upgrade logins to rest-region domain. They were still using the old rest.region which may break in the future (if it hasn't already)

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
