### PR TITLE
Remove thumbnail from homescreen method

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -117,13 +117,16 @@ class BlinkCamera():
             _LOGGER.warning("Could not retrieve calibrated temperature.")
 
         # Check if thumbnail exists in config, if not try to
-        # get it from the homescreen info in teh sync module
+        # get it from the homescreen info in the sync module
         # otherwise set it to None and log an error
         new_thumbnail = None
+        thumb_addr = None
         if config['thumbnail']:
             thumb_addr = config['thumbnail']
         else:
-            thumb_addr = self.get_thumb_from_homescreen()
+            _LOGGER.warning("Could not find thumbnail for camera %s",
+                            self.name,
+                            exc_info=True)
 
         if thumb_addr is not None:
             new_thumbnail = "{}{}.jpg".format(self.sync.urls.base_url,
@@ -192,19 +195,3 @@ class BlinkCamera():
             return
         with open(path, 'wb') as vidfile:
             copyfileobj(response.raw, vidfile)
-
-    def get_thumb_from_homescreen(self):
-        """Retrieve thumbnail from homescreen."""
-        for device in self.sync.homescreen['devices']:
-            try:
-                device_type = device['device_type']
-                device_name = device['name']
-                device_thumb = device['thumbnail']
-                if device_type == 'camera' and device_name == self.name:
-                    return device_thumb
-            except KeyError:
-                pass
-        _LOGGER.error("Could not find thumbnail for camera %s",
-                      self.name,
-                      exc_info=True)
-        return None

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -99,45 +99,6 @@ class TestBlinkCameraSetup(unittest.TestCase):
         self.assertEqual(self.camera.image_from_cache, 'test')
         self.assertEqual(self.camera.video_from_cache, 'foobar')
 
-    def test_thumbnail_not_in_info(self, mock_sess):
-        """Test that we grab thumbanil if not in camera_info."""
-        mock_sess.side_effect = [
-            mresp.MockResponse({'temp': 71}, 200),
-            'foobar',
-            'barfoo'
-        ]
-        self.camera.last_record = ['1']
-        self.camera.sync.last_record = {
-            'new': {
-                'clip': '/test.mp4',
-                'time': '1970-01-01T00:00:00'
-            }
-        }
-        config = {
-            'name': 'new',
-            'id': 1234,
-            'network_id': 5678,
-            'serial': '12345678',
-            'enabled': False,
-            'battery_voltage': 90,
-            'battery_state': 'ok',
-            'temperature': 68,
-            'wifi_strength': 4,
-            'thumbnail': '',
-        }
-        self.camera.sync.homescreen = {
-            'devices': [
-                {'foo': 'bar'},
-                {'device_type': 'foobar'},
-                {'device_type': 'camera',
-                 'name': 'new',
-                 'thumbnail': '/new/thumb'}
-            ]
-        }
-        self.camera.update(config)
-        self.assertEqual(self.camera.thumbnail,
-                         'https://rest-test.immedia-semi.com/new/thumb.jpg')
-
     def test_no_thumbnails(self, mock_sess):
         """Tests that thumbnail is 'None' if none found."""
         mock_sess.return_value = 'foobar'
@@ -167,7 +128,7 @@ class TestBlinkCameraSetup(unittest.TestCase):
             logrecord.output,
             [("WARNING:blinkpy.camera:Could not retrieve calibrated "
               "temperature."),
-             ("ERROR:blinkpy.camera:Could not find thumbnail for camera new"
+             ("WARNING:blinkpy.camera:Could not find thumbnail for camera new"
               "\nNoneType: None")]
         )
 


### PR DESCRIPTION
## Description:
Removes backup thumbnail acquisition method since it referenced a property long removed from another module (and also would not work for multi-sync unit systems). 

**Related issue (if applicable):** fixes #184 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended

