### PR TITLE
Improved timeout, prevent blocking on startup when unable to login

### DIFF
--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -2,7 +2,7 @@
 
 import logging
 import time
-from functools import wraps
+from functools import partial, wraps
 from requests import Request, Session, exceptions
 from blinkpy.helpers.constants import BLINK_URL, TIMESTAMP_FORMAT
 import blinkpy.helpers.errors as ERROR
@@ -28,8 +28,14 @@ def merge_dicts(dict_a, dict_b):
 
 
 def create_session():
-    """Create a session for blink communication."""
+    """
+    Create a session for blink communication.
+
+    From @ericfrederich via
+    https://github.com/kennethreitz/requests/issues/2011
+    """
     sess = Session()
+    sess.get = partial(sess.get, timeout=5)
     return sess
 
 
@@ -65,7 +71,7 @@ def http_req(blink, url='http://example.com', data=None, headers=None,
     prepped = req.prepare()
 
     try:
-        response = blink.session.send(prepped, stream=stream, timeout=10)
+        response = blink.session.send(prepped, stream=stream)
         if json_resp and 'code' in response.json():
             if is_retry:
                 _LOGGER.error("Cannot obtain new token for server auth.")

--- a/tests/test_blink_functions.py
+++ b/tests/test_blink_functions.py
@@ -69,7 +69,8 @@ class TestBlinkFunctions(unittest.TestCase):
             bad_req,
             new_req
         ]
-        self.blink.login_request(['test1', 'test2', 'test3'])
+        self.blink.login_urls = ['test1', 'test2', 'test3']
+        self.blink.login_request()
         # pylint: disable=protected-access
         self.assertEqual(self.blink._login_url, 'test3')
 
@@ -78,7 +79,8 @@ class TestBlinkFunctions(unittest.TestCase):
             new_req,
             bad_req
         ]
-        self.blink.login_request(['test1', 'test2', 'test3'])
+        self.blink.login_urls = ['test1', 'test2', 'test3']
+        self.blink.login_request()
         # pylint: disable=protected-access
         self.assertEqual(self.blink._login_url, 'test2')
 


### PR DESCRIPTION
## Description:
Improved timeout for sessions (I think) and fixed problem where failed login would cause library to hang on startup.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
