### PR TITLE
Only store motion clip if motion occurred since last refresh

### DIFF
--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -188,8 +188,9 @@ class BlinkSyncModule():
                 name = entry['device_name']
                 clip = entry['media']
                 timestamp = entry['created_at']
-                self.motion[name] = self.check_new_video_time(timestamp)
-                self.last_record[name] = {'clip': clip, 'time': timestamp}
+                if self.check_new_video_time(timestamp):
+                    self.motion[name] = True
+                    self.last_record[name] = {'clip': clip, 'time': timestamp}
             except KeyError:
                 _LOGGER.debug("No new videos since last refresh.")
 


### PR DESCRIPTION
## Description:
Add check for motion prior to saving info.  Previously if the last item in the clip dictionary (which is unordered) happened prior to last refresh, the motion_detected variable would be over-written resulting in the last motion clip to NOT be saved and, subsequently, unavailable for download.

**Related issue (if applicable):** fixes #206 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
