### PR TITLE
Mask motion detection with sync module arm status

### DIFF
--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -189,7 +189,7 @@ class BlinkSyncModule():
                 clip = entry['media']
                 timestamp = entry['created_at']
                 if self.check_new_video_time(timestamp):
-                    self.motion[name] = True
+                    self.motion[name] = True and self.arm
                     self.last_record[name] = {'clip': clip, 'time': timestamp}
             except KeyError:
                 _LOGGER.debug("No new videos since last refresh.")

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -43,6 +43,7 @@ class TestBlinkSyncModule(unittest.TestCase):
             None,
             {'devicestatus': {}},
         ]
+        self.blink.sync['test'].network_info = {'network': {'armed': True}}
 
     def tearDown(self):
         """Clean up after test."""
@@ -106,6 +107,24 @@ class TestBlinkSyncModule(unittest.TestCase):
         sync_module = self.blink.sync['test']
         sync_module.cameras = {'foo': None}
         sync_module.blink.last_refresh = 1000
+        self.assertTrue(sync_module.check_new_videos())
+        self.assertEqual(sync_module.motion, {'foo': False})
+
+    def test_check_no_motion_if_not_armed(self, mock_resp):
+        """Test that motion detection is not set if module unarmed."""
+        mock_resp.return_value = {
+            'media': [{
+                'device_name': 'foo',
+                'media': '/foo/bar.mp4',
+                'created_at': '1990-01-01T00:00:00+00:00'
+            }]
+        }
+        sync_module = self.blink.sync['test']
+        sync_module.cameras = {'foo': None}
+        sync_module.blink.last_refresh = 1000
+        self.assertTrue(sync_module.check_new_videos())
+        self.assertEqual(sync_module.motion, {'foo': True})
+        sync_module.network_info = {'network': {'armed': False}}
         self.assertTrue(sync_module.check_new_videos())
         self.assertEqual(sync_module.motion, {'foo': False})
 


### PR DESCRIPTION
## Description:
Adds masking of camera motion detection with system arm status to prevent weird things from happening

**Related issue (if applicable):** fixes #199

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
