### PR TITLE
Log response code and message if not trying to re-authorize

### DIFF
--- a/blinkpy/helpers/errors.py
+++ b/blinkpy/helpers/errors.py
@@ -11,3 +11,5 @@ AUTH_TOKEN = (
     "Authentication header incorrect.  Are you sure you received your token?"
 )
 REQUEST = (4, "Cannot perform request (get/post type incorrect)")
+
+BLINK_ERRORS = [101, 400, 404]

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -86,16 +86,21 @@ def http_req(blink, url='http://example.com', data=None, headers=None,
     try:
         response = blink.session.send(prepped, stream=stream)
         if json_resp and 'code' in response.json():
-            if is_retry:
+            resp_dict = response.json()
+            code = resp_dict['code']
+            message = resp_dict['message']
+            if is_retry and code in ERROR.BLINK_ERRORS:
                 _LOGGER.error("Cannot obtain new token for server auth.")
                 return None
-            else:
+            elif code in ERROR.BLINK_ERRORS:
                 headers = attempt_reauthorization(blink)
                 if not headers:
                     raise exceptions.ConnectionError
                 return http_req(blink, url=url, data=data, headers=headers,
                                 reqtype=reqtype, stream=stream,
                                 json_resp=json_resp, is_retry=True)
+            _LOGGER.warning("Response from server: %s - %s", code, message)
+
     except (exceptions.ConnectionError, exceptions.Timeout):
         _LOGGER.info("Cannot connect to server with url %s.", url)
         if not is_retry:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  branch: dev
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.02
+
+comment: true
+require_ci_to_pass: yes
+range: 65..90
+round: down
+precision: 1

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -123,8 +123,8 @@ class TestBlinkSetup(unittest.TestCase):
     def test_bad_request(self, mock_sess):
         """Check that we raise an Exception with a bad request."""
         self.blink.session = create_session()
-        explog = ("ERROR:blinkpy.helpers.util:"
-                  "Cannot obtain new token for server auth.")
+        explog = ("WARNING:blinkpy.helpers.util:"
+                  "Response from server: 200 - foo")
         with self.assertRaises(BlinkException):
             http_req(self.blink, reqtype='bad')
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
     LANG=en_US.UTF-8
     PYTHONPATH = {toxinidir}
 commands = 
-    pytest --timeout=9 --durations=10 
+    pytest --timeout=9 --durations=10 --cov=blinkpy --cov-report term-missing {posargs}
 deps = 
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_test.txt


### PR DESCRIPTION
## Description:
Checks response code and logs message if code does not correspond to a re-authorization attempt

**Related issue (if applicable):** fixes #213

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
