### PR TITLE
Handle json decode error

### DIFF
--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -111,12 +111,14 @@ class Auth:
         if not json_resp:
             return response
 
-        json_data = response.json()
         try:
+            json_data = response.json()
             if json_data["code"] in ERROR.BLINK_ERRORS:
                 raise exceptions.ConnectionError
         except KeyError:
             pass
+        except (AttributeError, ValueError):
+            raise BlinkBadResponse
 
         return json_data
 
@@ -161,6 +163,8 @@ class Auth:
                     )
             except (TokenRefreshFailed, LoginError):
                 _LOGGER.error("Endpoint %s failed. Unable to refresh login tokens", url)
+        except BlinkBadResponse:
+            _LOGGER.error("Expected json response, but received: %s", response)
         _LOGGER.error("Endpoint %s failed", url)
         return None
 
@@ -192,3 +196,7 @@ class TokenRefreshFailed(Exception):
 
 class LoginError(Exception):
     """Class to throw failed login exception."""
+
+
+class BlinkBadResponse(Exception):
+    """Class to throw bad json response exception."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@
 import unittest
 from unittest import mock
 from requests import exceptions
-from blinkpy.auth import Auth, LoginError, TokenRefreshFailed
+from blinkpy.auth import Auth, LoginError, TokenRefreshFailed, BlinkBadResponse
 import blinkpy.helpers.constants as const
 import tests.mock_responses as mresp
 
@@ -99,6 +99,11 @@ class TestAuth(unittest.TestCase):
         """Check response when not json."""
         fake_resp = "foobar"
         self.assertEqual(self.auth.validate_response(fake_resp, False), "foobar")
+
+    def test_response_bad_json(self):
+        """Check response when not json but expecting json."""
+        with self.assertRaises(BlinkBadResponse):
+            self.auth.validate_response(None, True)
 
     def test_header(self):
         """Test header data."""


### PR DESCRIPTION
## Description:
Catches if response is expected to be json formatted but returns something else.

**Related issue (if applicable):** fixes #267 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
