### PR TITLE
Catch all None responses from http requests

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -152,7 +152,7 @@ class Blink:
                     {"name": camera["name"], "id": camera["id"]}
                 )
             return all_cameras
-        except KeyError:
+        except (KeyError, TypeError):
             _LOGGER.error("Unable to retrieve cameras from response %s", response)
             raise BlinkSetupError
 
@@ -176,7 +176,7 @@ class Blink:
         response = api.request_networks(self)
         try:
             self.networks = response["summary"]
-        except KeyError:
+        except (KeyError, TypeError):
             raise BlinkSetupError
 
     def setup_network_ids(self):
@@ -250,8 +250,8 @@ class Blink:
             try:
                 result = response["media"]
                 if not result:
-                    raise IndexError
-            except (KeyError, IndexError):
+                    raise KeyError
+            except (KeyError, TypeError):
                 _LOGGER.info("No videos found on page %s. Exiting.", page)
                 break
 

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -149,14 +149,11 @@ class BlinkSyncModule:
 
     def get_network_info(self):
         """Retrieve network status."""
-        is_errored = False
         self.network_info = api.request_network_status(self.blink, self.network_id)
         try:
-            is_errored = self.network_info["network"]["sync_module_error"]
-        except KeyError:
-            is_errored = True
-
-        if is_errored:
+            if self.network_info["network"]["sync_module_error"]:
+                raise KeyError
+        except (TypeError, KeyError):
             self.available = False
             return False
         return True

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -106,6 +106,9 @@ class TestBlinkSetup(unittest.TestCase):
         mock_home.return_value = {}
         with self.assertRaises(BlinkSetupError):
             self.blink.setup_camera_list()
+        mock_home.return_value = None
+        with self.assertRaises(BlinkSetupError):
+            self.blink.setup_camera_list()
 
     def test_setup_urls(self):
         """Check setup of URLS."""
@@ -130,6 +133,9 @@ class TestBlinkSetup(unittest.TestCase):
     def test_setup_networks_failure(self, mock_networks):
         """Check that on failure we raise a setup error."""
         mock_networks.return_value = {}
+        with self.assertRaises(BlinkSetupError):
+            self.blink.setup_networks()
+        mock_networks.return_value = None
         with self.assertRaises(BlinkSetupError):
             self.blink.setup_networks()
 

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -78,13 +78,31 @@ class TestBlinkSyncModule(unittest.TestCase):
         self.assertEqual(self.blink.sync["test"].get_camera_info("1234"), "foobar")
 
     def test_get_camera_info_fail(self, mock_resp):
-        """Test hadnling of failed get camera info function."""
+        """Test handling of failed get camera info function."""
         mock_resp.return_value = None
         self.assertEqual(self.blink.sync["test"].get_camera_info("1"), [])
         mock_resp.return_value = {}
         self.assertEqual(self.blink.sync["test"].get_camera_info("1"), [])
         mock_resp.return_value = {"camera": None}
         self.assertEqual(self.blink.sync["test"].get_camera_info("1"), [])
+
+    def test_get_network_info(self, mock_resp):
+        """Test network retrieval."""
+        mock_resp.return_value = {"network": {"sync_module_error": False}}
+        self.assertTrue(self.blink.sync["test"].get_network_info())
+        mock_resp.return_value = {"network": {"sync_module_error": True}}
+        self.assertFalse(self.blink.sync["test"].get_network_info())
+
+    def test_get_network_info_failure(self, mock_resp):
+        """Test failed network retrieval."""
+        mock_resp.return_value = {}
+        self.blink.sync["test"].available = True
+        self.assertFalse(self.blink.sync["test"].get_network_info())
+        self.assertFalse(self.blink.sync["test"].available)
+        self.blink.sync["test"].available = True
+        mock_resp.return_value = None
+        self.assertFalse(self.blink.sync["test"].get_network_info())
+        self.assertFalse(self.blink.sync["test"].available)
 
     def test_check_new_videos_startup(self, mock_resp):
         """Test that check_new_videos does not block startup."""


### PR DESCRIPTION
## Description:
When blink throttles requests, response from server returns None.  This PR adds checks to catch those response and log an error (where appropriate) and mark the device as unavailable.

**Related issue (if applicable):** fixes #270 
## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
