### PR TITLE
Add arm property to camera, deprecate motion enable method

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -77,12 +77,31 @@ class BlinkCamera:
             return self._cached_video
         return None
 
+    @property
+    def arm(self):
+        """Return arm status of camera."""
+        return self.motion_enabled
+
+    @arm.setter
+    def arm(self, value):
+        """Set camera arm status."""
+        if value:
+            return api.request_motion_detection_enable(
+                self.sync.blink, self.network_id, self.camera_id
+            )
+        return api.request_motion_detection_disable(
+            self.sync.blink, self.network_id, self.camera_id
+        )
+
     def snap_picture(self):
         """Take a picture with camera to create a new thumbnail."""
         return api.request_new_image(self.sync.blink, self.network_id, self.camera_id)
 
     def set_motion_detect(self, enable):
         """Set motion detection."""
+        _LOGGER.warning(
+            "Method is deprecated as of v0.16.0 and will be removed in a future version. Please use the BlinkCamera.arm property instead."
+        )
         if enable:
             return api.request_motion_detection_enable(
                 self.sync.blink, self.network_id, self.camera_id

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -144,6 +144,15 @@ class TestBlinkCameraSetup(unittest.TestCase):
         self.assertEqual(self.camera.clip, None)
         self.assertEqual(self.camera.video_from_cache, None)
 
+    def test_camera_arm_status(self, mock_resp):
+        """Test arming and disarming camera."""
+        self.camera.motion_enabled = None
+        self.assertFalse(self.camera.arm)
+        self.camera.motion_enabled = False
+        self.assertFalse(self.camera.arm)
+        self.camera.motion_enabled = True
+        self.assertTrue(self.camera.arm)
+
     @mock.patch("blinkpy.camera.api.request_motion_detection_enable")
     @mock.patch("blinkpy.camera.api.request_motion_detection_disable")
     def test_motion_detection_enable_disable(self, mock_dis, mock_en, mock_rep):


### PR DESCRIPTION
## Breaking Change:
The `BlinkCamera.set_motion_detect()` method is deprecated and being replaced with `BlinkCamera.arm`.  Usage is as follows:

To arm/disarm a `BlinkCamera` object named `camera`, just set the `arm` property to either `True` or `False` like so:

```python
camera.arm = True
```

Calling the same property will return the last updated camera status (perform a refresh at the sync module or blink level to update the status after setting).

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
