### PR TITLE
Add more data to the cred file

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -258,7 +258,7 @@ def http_get(blink, url, stream=False, json=True, is_retry=False):
     :param json: Return json response? TRUE/False
     :param is_retry: Is this part of a re-auth attempt?
     """
-    _LOGGER.debug("Making GET request to %s", url)
+    _LOGGER.error("Making GET request to %s", url)
     return blink.auth.query(
         url=url,
         headers=blink.auth.header,

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -60,6 +60,12 @@ def request_networks(blink):
     return http_get(blink, url)
 
 
+def request_user(blink):
+    """Get user information from blink servers."""
+    url = f"{blink.urls.base_url}/user"
+    return http_get(blink, url)
+
+
 def request_network_status(blink, network):
     """
     Request network information.

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -258,7 +258,7 @@ def http_get(blink, url, stream=False, json=True, is_retry=False):
     :param json: Return json response? TRUE/False
     :param is_retry: Is this part of a re-auth attempt?
     """
-    _LOGGER.error("Making GET request to %s", url)
+    _LOGGER.debug("Making GET request to %s", url)
     return blink.auth.query(
         url=url,
         headers=blink.auth.header,

--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -200,10 +200,11 @@ class Auth:
                 return False
         return True
 
-    def check_key_required(self):
+    def check_key_required(self, blink):
         """Check if 2FA key is required."""
         try:
-            if self.login_response["client"]["verification_required"]:
+            response = api.request_user(blink)
+            if response["verification_required"]:
                 return True
         except (KeyError, TypeError):
             pass

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -85,7 +85,13 @@ class BlinkSyncModule:
 
     def start(self):
         """Initialize the system."""
-        response = api.request_syncmodule(self.blink, self.network_id)
+        try:
+            response = self.blink.auth.login_attributes["sync"]
+            if response is None:
+                raise KeyError
+        except KeyError:
+            response = api.request_syncmodule(self.blink, self.network_id)
+        self.blink.auth.data["sync"] = response
         try:
             self.summary = response["syncmodule"]
             self.network_id = self.summary["network_id"]
@@ -107,7 +113,6 @@ class BlinkSyncModule:
             )
 
         is_ok = self.get_network_info()
-        self.check_new_videos()
         try:
             for camera_config in self.camera_list:
                 if "name" not in camera_config:
@@ -140,7 +145,13 @@ class BlinkSyncModule:
 
     def get_camera_info(self, camera_id):
         """Retrieve camera information."""
-        response = api.request_camera_info(self.blink, self.network_id, camera_id)
+        try:
+            response = self.blink.auth.login_attributes["camera_info"]
+            if response is None:
+                raise KeyError
+        except KeyError:
+            response = api.request_camera_info(self.blink, self.network_id, camera_id)
+        self.blink.auth.data["camera_info"] = response
         try:
             return response["camera"][0]
         except (TypeError, KeyError):


### PR DESCRIPTION
## Description:
Adds more login info to cred file to eliminate the need for some api calls at startup.

Note- need to add a way to force re-generation of network data in case new devices are added (maybe an input parameter to the auth class to say "delete these keys")

**Related issue (if applicable):** related #279 

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
