### PR TITLE
Update camera retrieval method (no more homescreen use)

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -141,15 +141,16 @@ class Blink:
     def setup_camera_list(self):
         """Create camera list for onboarded networks."""
         all_cameras = {}
-        response = api.request_homescreen(self)
+        response = api.request_camera_usage(self)
         try:
-            for camera in response["cameras"]:
-                camera_network = str(camera["network_id"])
+            for network in response["networks"]:
+                camera_network = str(network["network_id"])
                 if camera_network not in all_cameras:
                     all_cameras[camera_network] = []
-                all_cameras[camera_network].append(
-                    {"name": camera["name"], "id": camera["id"]}
-                )
+                for camera in network["cameras"]:
+                    all_cameras[camera_network].append(
+                        {"name": camera["name"], "id": camera["id"]}
+                    )
             return all_cameras
         except (KeyError, TypeError):
             _LOGGER.error("Unable to retrieve cameras from response %s", response)

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -149,7 +149,7 @@ class BlinkSyncModule:
 
     def get_network_info(self):
         """Retrieve network status."""
-        self.network_info = api.request_network_status(self.blink, self.network_id)
+        self.network_info = api.request_network_update(self.blink, self.network_id)
         try:
             if self.network_info["network"]["sync_module_error"]:
                 raise KeyError

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -81,14 +81,19 @@ class TestBlinkSetup(unittest.TestCase):
         self.assertEqual(self.blink.sync["TEST"], 1234)
         self.assertEqual(self.blink.sync["tEsT"], 1234)
 
-    @mock.patch("blinkpy.api.request_homescreen")
-    def test_setup_cameras(self, mock_home):
+    @mock.patch("blinkpy.api.request_camera_usage")
+    def test_setup_cameras(self, mock_req):
         """Check retrieval of camera information."""
-        mock_home.return_value = {
-            "cameras": [
-                {"name": "foo", "network_id": 1234, "id": 5678},
-                {"name": "bar", "network_id": 1234, "id": 5679},
-                {"name": "test", "network_id": 4321, "id": 0000},
+        mock_req.return_value = {
+            "networks": [
+                {
+                    "network_id": 1234,
+                    "cameras": [
+                        {"id": 5678, "name": "foo"},
+                        {"id": 5679, "name": "bar"},
+                    ],
+                },
+                {"network_id": 4321, "cameras": [{"id": 0000, "name": "test"}]},
             ]
         }
         result = self.blink.setup_camera_list()
@@ -100,7 +105,7 @@ class TestBlinkSetup(unittest.TestCase):
             },
         )
 
-    @mock.patch("blinkpy.api.request_homescreen")
+    @mock.patch("blinkpy.api.request_camera_usage")
     def test_setup_cameras_failure(self, mock_home):
         """Check that on failure we raise a setup error."""
         mock_home.return_value = {}


### PR DESCRIPTION
## Description:
Removes use of `request_homescreen` method to retrieve cameras in favor of a newer endpoint.  This also appears to fix inadvertent triggers for 2FA authentication every 24hrs.  Also updates a endpoint in the sync module refresh method.

**Related issue (if applicable):** MIGHT fix #249 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
