### PR TITLE
Add option to skip homescreen check

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -40,7 +40,10 @@ class Blink:
     """Class to initialize communication."""
 
     def __init__(
-        self, refresh_rate=DEFAULT_REFRESH, motion_interval=DEFAULT_MOTION_INTERVAL,
+        self,
+        refresh_rate=DEFAULT_REFRESH,
+        motion_interval=DEFAULT_MOTION_INTERVAL,
+        no_owls=False,
     ):
         """
         Initialize Blink system.
@@ -51,6 +54,7 @@ class Blink:
                                 Defaults to last refresh time.
                                 Useful for preventing motion_detected property
                                 from de-asserting too quickly.
+        :param no_owls: Disable searching for owl entries (blink mini cameras only known entity).  Prevents an uneccessary API call if you don't have these in your network.
         """
         self.auth = Auth()
         self.account_id = None
@@ -68,6 +72,7 @@ class Blink:
         self.available = False
         self.key_required = False
         self.homescreen = {}
+        self.no_owls = no_owls
 
     @util.Throttle(seconds=MIN_THROTTLE_TIME)
     def refresh(self, force=False):
@@ -141,6 +146,9 @@ class Blink:
 
     def setup_owls(self):
         """Check for mini cameras."""
+        if self.no_owls:
+            _LOGGER.debug("Skipping owl extraction.")
+            return []
         response = api.request_homescreen(self)
         self.homescreen = response
         network_list = []

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -259,6 +259,12 @@ class TestBlinkSetup(unittest.TestCase):
             result, [{"1234": {"name": "foo", "id": "1234", "type": "mini"}}]
         )
 
+        self.blink.no_owls = True
+        self.blink.network_ids = []
+        result = self.blink.setup_owls()
+        self.assertEqual(self.blink.network_ids, [])
+        self.assertEqual(result, [])
+
     @mock.patch("blinkpy.api.request_homescreen")
     @mock.patch("blinkpy.api.request_camera_usage")
     def test_blink_mini_attached_to_sync(self, mock_usage, mock_home):


### PR DESCRIPTION
## Description:
Add option at Blink instantiation to skip checking for owl entries (blink mini cameras)

```python
blink = Blink(no_owls=True)
```

Saves an uneccessary API call and _maybe_ fixes 24hr repeated request for 2fa key.

**Related issue (if applicable):** #279 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
