### PR TITLE
Removed 'reauth' key from login payload

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -32,7 +32,7 @@ def request_login(
             "client_name": "Computer",
             "client_type": "android",
             "os_version": "5.1.1",
-            "reauth": "true",
+            "reauth": "false",
         }
     )
     return auth.query(


### PR DESCRIPTION
## Description:
Setting the 'reauth' key to 'false' in the login payload seems to have stopped triggering 24hr 2FA key refreshes (that seemed to be ignored anyways).  Longer term testing is required to verify the fix.

**Related issue (if applicable):** fixes #279 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
