### PR TITLE
Broke out homescreen call to prevent back-to-back api calls

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -100,6 +100,7 @@ class Blink:
             self.auth.startup()
             self.setup_login_ids()
             self.setup_urls()
+            self.get_homescreen()
         except (LoginError, TokenRefreshFailed, BlinkSetupError):
             _LOGGER.error("Cannot setup Blink platform.")
             self.available = False
@@ -144,17 +145,20 @@ class Blink:
         self.sync[name] = BlinkSyncModule(self, name, network_id, cameras)
         self.sync[name].start()
 
-    def setup_owls(self):
-        """Check for mini cameras."""
+    def get_homescreen(self):
+        """Get homecreen information."""
         if self.no_owls:
             _LOGGER.debug("Skipping owl extraction.")
-            return []
-        response = api.request_homescreen(self)
-        self.homescreen = response
+            self.homescreen = {}
+            return
+        self.homescreen = api.request_homescreen(self)
+
+    def setup_owls(self):
+        """Check for mini cameras."""
         network_list = []
         camera_list = []
         try:
-            for owl in response["owls"]:
+            for owl in self.homescreen["owls"]:
                 name = owl["name"]
                 network_id = str(owl["network_id"])
                 if network_id in self.network_ids:

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -197,12 +197,11 @@ class TestBlinkSetup(unittest.TestCase):
         self.assertEqual(combined["fizz"], "buzz")
         self.assertEqual(combined["bar"], "foo")
 
-    @mock.patch("blinkpy.api.request_homescreen")
     @mock.patch("blinkpy.blinkpy.BlinkOwl.start")
-    def test_initialize_blink_minis(self, mock_start, mock_home):
+    def test_initialize_blink_minis(self, mock_start):
         """Test blink mini initialization."""
         mock_start.return_value = True
-        mock_home.return_value = {
+        self.blink.homescreen = {
             "owls": [
                 {
                     "enabled": False,
@@ -235,11 +234,10 @@ class TestBlinkSetup(unittest.TestCase):
         self.assertEqual(self.blink.sync["foo"].name, "foo")
         self.assertEqual(self.blink.sync["bar"].name, "bar")
 
-    @mock.patch("blinkpy.api.request_homescreen")
-    def test_blink_mini_cameras_returned(self, mock_home):
+    def test_blink_mini_cameras_returned(self):
         """Test that blink mini cameras are found if attached to sync module."""
         self.blink.network_ids = ["1234"]
-        mock_home.return_value = {
+        self.blink.homescreen = {
             "owls": [
                 {
                     "id": 1,
@@ -261,16 +259,16 @@ class TestBlinkSetup(unittest.TestCase):
 
         self.blink.no_owls = True
         self.blink.network_ids = []
+        self.blink.get_homescreen()
         result = self.blink.setup_owls()
         self.assertEqual(self.blink.network_ids, [])
         self.assertEqual(result, [])
 
-    @mock.patch("blinkpy.api.request_homescreen")
     @mock.patch("blinkpy.api.request_camera_usage")
-    def test_blink_mini_attached_to_sync(self, mock_usage, mock_home):
+    def test_blink_mini_attached_to_sync(self, mock_usage):
         """Test that blink mini cameras are properly attached to sync module."""
         self.blink.network_ids = ["1234"]
-        mock_home.return_value = {
+        self.blink.homescreen = {
             "owls": [
                 {
                     "id": 1,


### PR DESCRIPTION
## Description:
For implementations with `no_prompt=True` back-to-back API calls when looking for mini cameras caused a `BlinkSetupError` to be raised.  These calls have been separated and this bug should be fixed now.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
