### PR TITLE
Add option to use v3 login endpoint

### DIFF
--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 class Auth:
     """Class to handle login communication."""
 
-    def __init__(self, login_data=None, no_prompt=False):
+    def __init__(self, login_data=None, no_prompt=False, login_method="v4"):
         """
         Initialize auth handler.
 
@@ -22,6 +22,7 @@ class Auth:
                              - password
         :param no_prompt: Should any user input prompts
                           be supressed? True/FALSE
+        :param login_method: Choose the login endpoint to use. Default: v4.  v3 uses email verification rather than a 2FA code.
         """
         if login_data is None:
             login_data = {}
@@ -31,6 +32,7 @@ class Auth:
         self.region_id = login_data.get("region_id", None)
         self.client_id = login_data.get("client_id", None)
         self.account_id = login_data.get("account_id", None)
+        self.login_url = LOGIN_ENDPOINT[login_method]
         self.login_response = None
         self.is_errored = False
         self.no_prompt = no_prompt
@@ -73,11 +75,11 @@ class Auth:
 
         self.data = util.validate_login_data(self.data)
 
-    def login(self, login_url=LOGIN_ENDPOINT):
+    def login(self):
         """Attempt login to blink servers."""
         self.validate_login()
-        _LOGGER.info("Attempting login with %s", login_url)
-        response = api.request_login(self, login_url, self.data, is_retry=False,)
+        _LOGGER.info("Attempting login with %s", self.login_url)
+        response = api.request_login(self, self.login_url, self.data, is_retry=False,)
         try:
             if response.status_code == 200:
                 return response.json()

--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -4,7 +4,7 @@ import os
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 16
-PATCH_VERSION = "0-rc8"
+PATCH_VERSION = "0-rc9"
 
 __version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}"
 
@@ -48,7 +48,10 @@ URLS
 BLINK_URL = "immedia-semi.com"
 DEFAULT_URL = f"rest-prod.{BLINK_URL}"
 BASE_URL = f"https://{DEFAULT_URL}"
-LOGIN_ENDPOINT = f"{BASE_URL}/api/v4/account/login"
+LOGIN_ENDPOINT = {
+    "v4": f"{BASE_URL}/api/v4/account/login",
+    "v3": f"{BASE_URL}/api/v3/login",
+}
 
 """
 Dictionaries

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -144,6 +144,21 @@ class TestAuth(unittest.TestCase):
         fake_resp = mresp.MockResponse({"foo": "bar"}, 200)
         mock_req.return_value = fake_resp
         self.assertEqual(self.auth.login(), {"foo": "bar"})
+        mock_req.assert_called_with(
+            self.auth, const.LOGIN_ENDPOINT["v4"], {}, is_retry=False
+        )
+
+    @mock.patch("blinkpy.auth.Auth.validate_login", return_value=None)
+    @mock.patch("blinkpy.auth.api.request_login")
+    def test_login_v3(self, mock_req, mock_validate):
+        """Test login handling."""
+        auth_v3 = Auth(login_method="v3")
+        fake_resp = mresp.MockResponse({"foo": "bar"}, 200)
+        mock_req.return_value = fake_resp
+        self.assertEqual(auth_v3.login(), {"foo": "bar"})
+        mock_req.assert_called_with(
+            auth_v3, const.LOGIN_ENDPOINT["v3"], {}, is_retry=False
+        )
 
     @mock.patch("blinkpy.auth.Auth.validate_login", return_value=None)
     @mock.patch("blinkpy.auth.api.request_login")


### PR DESCRIPTION
## Description:
- Adds ability to initialize auth class with v3 endpoint instead of v4:

```python
auth = Auth(login_method="v3")
```

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
