### PR TITLE
Rolled back to rc8, removed v3 auth functionality (poorly thought out)

### DIFF
--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 class Auth:
     """Class to handle login communication."""
 
-    def __init__(self, login_data=None, no_prompt=False, login_method="v4"):
+    def __init__(self, login_data=None, no_prompt=False):
         """
         Initialize auth handler.
 
@@ -22,7 +22,6 @@ class Auth:
                              - password
         :param no_prompt: Should any user input prompts
                           be supressed? True/FALSE
-        :param login_method: Choose the login endpoint to use. Default: v4.  v3 uses email verification rather than a 2FA code.
         """
         if login_data is None:
             login_data = {}
@@ -32,7 +31,6 @@ class Auth:
         self.region_id = login_data.get("region_id", None)
         self.client_id = login_data.get("client_id", None)
         self.account_id = login_data.get("account_id", None)
-        self.login_method = login_method
         self.login_response = None
         self.is_errored = False
         self.no_prompt = no_prompt
@@ -55,13 +53,6 @@ class Auth:
             return None
         return {"Host": self.host, "TOKEN_AUTH": self.token}
 
-    @property
-    def login_url(self):
-        """Return login url."""
-        if self.login_method not in LOGIN_ENDPOINT:
-            return LOGIN_ENDPOINT["v4"]
-        return LOGIN_ENDPOINT[self.login_method]
-
     def create_session(self):
         """Create a session for blink communication."""
         sess = Session()
@@ -82,11 +73,11 @@ class Auth:
 
         self.data = util.validate_login_data(self.data)
 
-    def login(self):
+    def login(self, login_url=LOGIN_ENDPOINT):
         """Attempt login to blink servers."""
         self.validate_login()
-        _LOGGER.info("Attempting login with %s", self.login_url)
-        response = api.request_login(self, self.login_url, self.data, is_retry=False,)
+        _LOGGER.info("Attempting login with %s", login_url)
+        response = api.request_login(self, login_url, self.data, is_retry=False,)
         try:
             if response.status_code == 200:
                 return response.json()

--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -4,7 +4,7 @@ import os
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 16
-PATCH_VERSION = "0-rc10"
+PATCH_VERSION = "0-rc11"
 
 __version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}"
 
@@ -48,10 +48,7 @@ URLS
 BLINK_URL = "immedia-semi.com"
 DEFAULT_URL = f"rest-prod.{BLINK_URL}"
 BASE_URL = f"https://{DEFAULT_URL}"
-LOGIN_ENDPOINT = {
-    "v4": f"{BASE_URL}/api/v4/account/login",
-    "v3": f"{BASE_URL}/api/v3/login",
-}
+LOGIN_ENDPOINT = f"{BASE_URL}/api/v4/account/login"
 
 """
 Dictionaries

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-dateutil~=2.8.1
-requests~=2.24.0
+requests~=2.23.0
 python-slugify~=4.0.0
 testtools==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-dateutil~=2.8.1
-requests~=2.23.0
+requests~=2.24.0
 python-slugify~=4.0.0
 testtools==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -3,23 +3,26 @@
 from os.path import abspath, dirname
 from setuptools import setup, find_packages
 from blinkpy.helpers.constants import (
-    __version__, PROJECT_PACKAGE_NAME, PROJECT_LICENSE, PROJECT_URL,
-    PROJECT_EMAIL, PROJECT_DESCRIPTION, PROJECT_CLASSIFIERS, PROJECT_AUTHOR,
+    __version__,
+    PROJECT_PACKAGE_NAME,
+    PROJECT_LICENSE,
+    PROJECT_URL,
+    PROJECT_EMAIL,
+    PROJECT_DESCRIPTION,
+    PROJECT_CLASSIFIERS,
+    PROJECT_AUTHOR,
 )
 
 PROJECT_VERSION = __version__
 
 THIS_DIR = abspath(dirname(__file__))
 
-REQUIRES = [
-    "python-dateutil~=2.8.1",
-    "requests~=2.23.0",
-    "python-slugify~=4.0.0",
-]
+with open(f"{THIS_DIR}/requirements.txt") as req_file:
+    REQUIRES = [line.rstrip() for line in req_file]
 
-PACKAGES = find_packages(exclude=['tests*', 'docs'])
+PACKAGES = find_packages(exclude=["tests*", "docs"])
 
-with open('{}/README.rst'.format(THIS_DIR), encoding='utf-8') as readme_file:
+with open("{}/README.rst".format(THIS_DIR), encoding="utf-8") as readme_file:
     LONG_DESCRIPTION = readme_file.read()
 
 setup(
@@ -31,11 +34,11 @@ setup(
     author_email=PROJECT_EMAIL,
     license=PROJECT_LICENSE,
     url=PROJECT_URL,
-    platforms='any',
-    py_modules=['blinkpy'],
+    platforms="any",
+    py_modules=["blinkpy"],
     packages=PACKAGES,
     include_package_data=True,
     install_requires=REQUIRES,
-    test_suite='tests',
-    classifiers=PROJECT_CLASSIFIERS
+    test_suite="tests",
+    classifiers=PROJECT_CLASSIFIERS,
 )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -144,21 +144,6 @@ class TestAuth(unittest.TestCase):
         fake_resp = mresp.MockResponse({"foo": "bar"}, 200)
         mock_req.return_value = fake_resp
         self.assertEqual(self.auth.login(), {"foo": "bar"})
-        mock_req.assert_called_with(
-            self.auth, const.LOGIN_ENDPOINT["v4"], {}, is_retry=False
-        )
-
-    @mock.patch("blinkpy.auth.Auth.validate_login", return_value=None)
-    @mock.patch("blinkpy.auth.api.request_login")
-    def test_login_v3(self, mock_req, mock_validate):
-        """Test login handling."""
-        auth_v3 = Auth(login_method="v3")
-        fake_resp = mresp.MockResponse({"foo": "bar"}, 200)
-        mock_req.return_value = fake_resp
-        self.assertEqual(auth_v3.login(), {"foo": "bar"})
-        mock_req.assert_called_with(
-            auth_v3, const.LOGIN_ENDPOINT["v3"], {}, is_retry=False
-        )
 
     @mock.patch("blinkpy.auth.Auth.validate_login", return_value=None)
     @mock.patch("blinkpy.auth.api.request_login")
@@ -253,15 +238,6 @@ class TestAuth(unittest.TestCase):
 
         mock_validate.side_effect = [UnauthorizedError, TokenRefreshFailed]
         self.assertEqual(self.auth.query(url="http://example.com"), None)
-
-    def test_login_methods(self):
-        """Test correct login url returned."""
-        auth = Auth()
-        self.assertEqual(auth.login_url, const.LOGIN_ENDPOINT["v4"])
-        auth.login_method = "v3"
-        self.assertEqual(auth.login_url, const.LOGIN_ENDPOINT["v3"])
-        auth.login_method = "foobar"
-        self.assertEqual(auth.login_url, const.LOGIN_ENDPOINT["v4"])
 
 
 class MockSession:


### PR DESCRIPTION
## Description:
- Rolled back to rc8

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
