### PR TITLE
Remove reference to response on exception since it may be unbound

### DIFF
--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -171,10 +171,7 @@ class Auth:
             return self.validate_response(response, json_resp)
         except (exceptions.ConnectionError, exceptions.Timeout):
             _LOGGER.error(
-                "Connection error. Endpoint %s possibly down or throttled. %s: %s",
-                url,
-                response.status_code,
-                response.reason,
+                "Connection error. Endpoint %s possibly down or throttled.", url,
             )
         except BlinkBadResponse:
             _LOGGER.error(


### PR DESCRIPTION
## Description:
Fixed bug when `response` is unbound during a connection error which causes a bunch of exceptions to be thrown due to referencing `response` in the log statement.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
