### PR TITLE
Removed all exc_info parameters during logging

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -151,9 +151,7 @@ class BlinkCamera:
         if config.get("thumbnail", False):
             thumb_addr = config["thumbnail"]
         else:
-            _LOGGER.warning(
-                "Could not find thumbnail for camera %s", self.name, exc_info=True
-            )
+            _LOGGER.warning("Could not find thumbnail for camera %s", self.name)
 
         if thumb_addr is not None:
             new_thumbnail = f"{self.sync.urls.base_url}{thumb_addr}.jpg"

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -93,9 +93,7 @@ class BlinkSyncModule:
             self.serial = self.summary["serial"]
             self.status = self.summary["status"]
         except KeyError:
-            _LOGGER.error(
-                "Could not extract some sync module info: %s", response, exc_info=True
-            )
+            _LOGGER.error("Could not extract some sync module info: %s", response)
 
         is_ok = self.get_network_info()
         self.check_new_videos()
@@ -158,7 +156,7 @@ class BlinkSyncModule:
         try:
             return response["event"]
         except (TypeError, KeyError):
-            _LOGGER.error("Could not extract events: %s", response, exc_info=True)
+            _LOGGER.error("Could not extract events: %s", response)
             return False
 
     def get_camera_info(self, camera_id, **kwargs):
@@ -170,7 +168,7 @@ class BlinkSyncModule:
         try:
             return response["camera"][0]
         except (TypeError, KeyError):
-            _LOGGER.error("Could not extract camera info: %s", response, exc_info=True)
+            _LOGGER.error("Could not extract camera info: %s", response)
             return {}
 
     def get_network_info(self):

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -117,10 +117,7 @@ class TestBlinkCameraSetup(unittest.TestCase):
                     "WARNING:blinkpy.camera:Could not retrieve calibrated "
                     "temperature."
                 ),
-                (
-                    "WARNING:blinkpy.camera:Could not find thumbnail for camera new"
-                    "\nNoneType: None"
-                ),
+                ("WARNING:blinkpy.camera:Could not find thumbnail for camera new"),
             ],
         )
 


### PR DESCRIPTION
## Description:
Some logger calls still had `exc_info=True` in the logging statement which would cause a traceback to be printed.  I want to avoid this behavior, so found the stragglers and removed them.

**Related issue (if applicable):** might help with #335 

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ ] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
