### PR TITLE
Set min version for reqs instead of pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-dateutil~=2.8.1
-requests~=2.24.0
-python-slugify~=4.0.1
-testtools==2.4.0
+python-dateutil>=2.8.1
+requests>=2.24.0
+python-slugify>=4.0.1
+testtools>=2.4.0


### PR DESCRIPTION
## Description:
Set minimum version for packages rather than pinning to prevent issues with home-assistant integration

**Related issue (if applicable):** fixes #346 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ ] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
