### PR TITLE
Updated headers to include user-agent, removed extra data at login

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -3,7 +3,7 @@
 import logging
 from json import dumps
 from blinkpy.helpers.util import get_time, Throttle
-from blinkpy.helpers.constants import DEFAULT_URL, TIMEOUT
+from blinkpy.helpers.constants import DEFAULT_URL, TIMEOUT, DEFAULT_USER_AGENT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,21 +20,24 @@ def request_login(
     :param url: Login url.
     :login_data: Dictionary containing blink login data.
     """
-    headers = {"Host": DEFAULT_URL, "Content-Type": "application/json"}
+    headers = {
+        "Host": DEFAULT_URL,
+        "Content-Type": "application/json",
+        "Accept": "/",
+        "user-agent": DEFAULT_USER_AGENT,
+    }
     data = dumps(
         {
             "email": login_data["username"],
             "password": login_data["password"],
             "notification_key": login_data["notification_key"],
             "unique_id": login_data["uid"],
-            "app_version": "6.0.12",
             "device_identifier": login_data["device_id"],
             "client_name": "Computer",
-            "client_type": "android",
-            "os_version": "5.1.1",
-            "reauth": "true",
+            "reauth": "false",
         }
     )
+
     return auth.query(
         url=url,
         headers=headers,

--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -108,11 +108,7 @@ class Auth:
         try:
             _LOGGER.info("Token expired, attempting automatic refresh.")
             self.login_response = self.login()
-            self.region_id = self.login_response["region"]["tier"]
-            self.host = f"{self.region_id}.{BLINK_URL}"
-            self.token = self.login_response["authtoken"]["authtoken"]
-            self.client_id = self.login_response["client"]["id"]
-            self.account_id = self.login_response["account"]["id"]
+            self.extract_login_info()
             self.is_errored = False
         except LoginError:
             _LOGGER.error("Login endpoint failed. Try again later.")
@@ -121,6 +117,14 @@ class Auth:
             _LOGGER.error("Malformed login response: %s", self.login_response)
             raise TokenRefreshFailed
         return True
+
+    def extract_login_info(self):
+        """Extract login info from login response."""
+        self.region_id = self.login_response["region"]["tier"]
+        self.host = f"{self.region_id}.{BLINK_URL}"
+        self.token = self.login_response["authtoken"]["authtoken"]
+        self.client_id = self.login_response["client"]["id"]
+        self.account_id = self.login_response["account"]["id"]
 
     def startup(self):
         """Initialize tokens for communication."""

--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -4,7 +4,7 @@ import os
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 16
-PATCH_VERSION = "2-rc0"
+PATCH_VERSION = "2-rc1"
 
 __version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}"
 
@@ -58,6 +58,7 @@ ONLINE = {"online": True, "offline": False}
 """
 OTHER
 """
+DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
 DEVICE_ID = "Blinkpy"
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 DEFAULT_MOTION_INTERVAL = 1


### PR DESCRIPTION
## Description:
Adds user-agent to header.  Seems like without one, requests are failing at login.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
