### PR TITLE
Generalized image/video download, fixed non-updating image for minis

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -86,6 +86,7 @@ class Blink:
             if not self.available:
                 self.setup_post_verify()
 
+            self.get_homescreen()
             for sync_name, sync_module in self.sync.items():
                 _LOGGER.debug("Attempting refresh of sync %s", sync_name)
                 sync_module.refresh(force_cache=force)

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -98,6 +98,15 @@ class BlinkCamera:
             self.sync.blink, self.network_id, self.camera_id
         )
 
+    def get_media(self, media_type="image"):
+        """Download media (image or video)."""
+        url = self.thumbnail
+        if media_type.lower() == "video":
+            url = self.clip
+        return api.http_get(
+            self.sync.blink, url=url, stream=True, json=False, timeout=TIMEOUT_MEDIA,
+        )
+
     def snap_picture(self):
         """Take a picture with camera to create a new thumbnail."""
         return api.request_new_image(self.sync.blink, self.network_id, self.camera_id)
@@ -180,21 +189,10 @@ class BlinkCamera:
             update_cached_video = True
 
         if new_thumbnail is not None and (update_cached_image or force_cache):
-            self._cached_image = api.http_get(
-                self.sync.blink,
-                url=self.thumbnail,
-                stream=True,
-                json=False,
-                timeout=TIMEOUT_MEDIA,
-            )
+            self._cached_image = self.get_media()
+
         if clip_addr is not None and (update_cached_video or force_cache):
-            self._cached_video = api.http_get(
-                self.sync.blink,
-                url=self.clip,
-                stream=True,
-                json=False,
-                timeout=TIMEOUT_MEDIA,
-            )
+            self._cached_video = self.get_media(media_type="video")
 
     def get_liveview(self):
         """Get livewview rtsps link."""
@@ -210,7 +208,7 @@ class BlinkCamera:
         :param path: Path to write file
         """
         _LOGGER.debug("Writing image from %s to %s", self.name, path)
-        response = self._cached_image
+        response = self.get_media()
         if response.status_code == 200:
             with open(path, "wb") as imgfile:
                 copyfileobj(response.raw, imgfile)
@@ -226,7 +224,7 @@ class BlinkCamera:
         :param path: Path to write file
         """
         _LOGGER.debug("Writing video from %s to %s", self.name, path)
-        response = self._cached_video
+        response = self.get_media(media_type="video")
         if response is None:
             _LOGGER.error("No saved video exist for %s.", self.name)
             return

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -68,7 +68,7 @@ class TestBlinkSetup(unittest.TestCase):
         self.assertEqual(self.blink.last_refresh, None)
         with mock.patch(
             "blinkpy.sync_module.BlinkSyncModule.refresh", return_value=True
-        ):
+        ), mock.patch("blinkpy.blinkpy.Blink.get_homescreen", return_value=True):
             self.blink.refresh()
 
         self.assertEqual(self.blink.last_refresh, now)


### PR DESCRIPTION
## Description:
- Adds a new method to wrap image download (avoids repeated code).
- Changes image and video download method to always grab latest data from server rather than using cached data
- Adds homescreen call in refresh method to ensure Mini camera images are properly updated

**Related issue (if applicable):** fixes #369 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
