### PR TITLE
Added test to catch NoneType error on refresh, fixed offending code

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -76,21 +76,22 @@ class Blink:
         self.no_owls = no_owls
 
     @util.Throttle(seconds=MIN_THROTTLE_TIME)
-    def refresh(self, force=False):
+    def refresh(self, force=False, force_cache=False):
         """
         Perform a system refresh.
 
-        :param force: Force an update of the camera data
+        :param force: Used to override throttle, resets refresh
+        :param force_cache: Used to force update without overriding throttle
         """
-        if self.check_if_ok_to_update() or force:
+        if self.check_if_ok_to_update() or force or force_cache:
             if not self.available:
                 self.setup_post_verify()
 
             self.get_homescreen()
             for sync_name, sync_module in self.sync.items():
                 _LOGGER.debug("Attempting refresh of sync %s", sync_name)
-                sync_module.refresh(force_cache=force)
-            if not force:
+                sync_module.refresh(force_cache=(force or force_cache))
+            if not force_cache:
                 # Prevents rapid clearing of motion detect property
                 self.last_refresh = int(time.time())
             return True

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -145,7 +145,7 @@ class BlinkSyncModule:
             for owl in self.blink.homescreen["owls"]:
                 if owl["name"] == name:
                     return owl
-        except KeyError:
+        except (TypeError, KeyError):
             pass
         return None
 
@@ -270,7 +270,7 @@ class BlinkOwl(BlinkSyncModule):
                 if owl["name"] == self.name:
                     self.status = owl["enabled"]
                     return owl
-        except KeyError:
+        except (TypeError, KeyError):
             pass
         return None
 

--- a/tests/test_blink_functions.py
+++ b/tests/test_blink_functions.py
@@ -5,29 +5,23 @@ import logging
 
 from blinkpy import blinkpy
 from blinkpy.sync_module import BlinkSyncModule
+from blinkpy.camera import BlinkCamera
 from blinkpy.helpers.util import get_time, BlinkURLHandler
 
 
 class MockSyncModule(BlinkSyncModule):
-    """Mock http requests from sync module."""
+    """Mock blink sync module object."""
 
-    def __init__(self, blink, header):
-        """Create mock sync module instance."""
-        super().__init__(blink, header, network_id=None, camera_list=None)
-        self.blink = blink
-        self.header = header
-        self.return_value = None
-        self.return_value2 = None
+    def get_network_info(self):
+        """Mock network info method."""
+        return True
 
-    def http_get(self, url, stream=False, json=True):
-        """Mock get request."""
-        if stream and self.return_value2 is not None:
-            return self.return_value2
-        return self.return_value
 
-    def http_post(self, url):
-        """Mock post request."""
-        return self.return_value
+class MockCamera(BlinkCamera):
+    """Mock blink camera object."""
+
+    def update(self, config, force_cache=False, **kwargs):
+        """Mock camera update method."""
 
 
 class TestBlinkFunctions(unittest.TestCase):
@@ -121,3 +115,16 @@ class TestBlinkFunctions(unittest.TestCase):
         with self.assertLogs() as dl_log:
             blink.download_videos("/tmp", camera="bar", stop=2)
         self.assertEqual(dl_log.output, expected_log)
+
+    @mock.patch("blinkpy.blinkpy.api.request_network_update")
+    @mock.patch("blinkpy.auth.Auth.query")
+    def test_refresh(self, mock_req, mock_update):
+        """Test ability to refresh system."""
+        mock_update.return_value = {"network": {"sync_module_error": False}}
+        mock_req.return_value = None
+        self.blink.last_refresh = 0
+        self.blink.available = True
+        self.blink.sync["foo"] = MockSyncModule(self.blink, "foo", 1, [])
+        self.blink.cameras = {"bar": MockCamera(self.blink.sync)}
+        self.blink.sync["foo"].cameras = self.blink.cameras
+        self.assertTrue(self.blink.refresh())

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -69,7 +69,7 @@ class TestBlinkSetup(unittest.TestCase):
         with mock.patch(
             "blinkpy.sync_module.BlinkSyncModule.refresh", return_value=True
         ), mock.patch("blinkpy.blinkpy.Blink.get_homescreen", return_value=True):
-            self.blink.refresh()
+            self.blink.refresh(force=True)
 
         self.assertEqual(self.blink.last_refresh, now)
         self.assertEqual(self.blink.check_if_ok_to_update(), False)


### PR DESCRIPTION
## Description:
Adds exception catch to prevent NoneType error on refresh, added test to check behavior as well
- Unrelated: had to add two force methods to refresh for testing purposes.  Should not change normal usage.

**Related issue (if applicable):** fixes #392 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
