### PR TITLE
Add content type to header to fix downloading

### DIFF
--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -58,7 +58,11 @@ class Auth:
         """Return authorization header."""
         if self.token is None:
             return None
-        return {"TOKEN_AUTH": self.token, "user-agent": DEFAULT_USER_AGENT}
+        return {
+            "TOKEN_AUTH": self.token,
+            "user-agent": DEFAULT_USER_AGENT,
+            "content-type": "application/json",
+        }
 
     def create_session(self, opts=None):
         """Create a session for blink communication."""
@@ -227,6 +231,9 @@ class Auth:
             try:
                 json_resp = response.json()
                 blink.available = json_resp["valid"]
+                if not json_resp["valid"]:
+                    _LOGGER.error(f"{json_resp['message']}")
+                    return False
             except (KeyError, TypeError):
                 _LOGGER.error("Did not receive valid response from server.")
                 return False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -128,7 +128,11 @@ class TestAuth(unittest.TestCase):
     def test_header(self):
         """Test header data."""
         self.auth.token = "bar"
-        expected_header = {"TOKEN_AUTH": "bar", "user-agent": const.DEFAULT_USER_AGENT}
+        expected_header = {
+            "TOKEN_AUTH": "bar",
+            "user-agent": const.DEFAULT_USER_AGENT,
+            "content-type": "application/json",
+        }
         self.assertDictEqual(self.auth.header, expected_header)
 
     def test_header_no_token(self):


### PR DESCRIPTION
## Description:
Fix video downloading by adding `"content-type": "application/json"` to the header. No undesired behavior observed in tests (arming/snapshots/etc)

**Related issue (if applicable):** fixes #422 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
