### PR TITLE
Add Blink Doorbell basic functions

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -273,3 +273,42 @@ class BlinkCameraMini(BlinkCamera):
         server_split[0] = "rtsps:"
         link = "".join(server_split)
         return link
+
+
+class BlinkDoorbell(BlinkCamera):
+    """Define a class for a Blink Doorbell camera."""
+
+    def __init__(self, sync):
+        """Initialize a Blink Doorbell."""
+        super().__init__(sync)
+        self.camera_type = "doorbell"
+
+    @property
+    def arm(self):
+        """Return camera arm status."""
+        return self.sync.arm
+
+    @arm.setter
+    def arm(self, value):
+        """Set camera arm status."""
+        _LOGGER.warning(
+            "Individual camera motion detection enable/disable for Blink Doorbell is unsupported at this time."
+        )
+
+    def snap_picture(self):
+        """Snap picture for a blink doorbell camera."""
+        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.network_id}/lotus/{self.camera_id}/thumbnail"
+        return api.http_post(self.sync.blink, url)
+
+    def get_sensor_info(self):
+        """Get sensor info for blink doorbell camera."""
+
+    def get_liveview(self):
+        """Get liveview link."""
+        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.network_id}/lotus/{self.camera_id}/liveview"
+        response = api.http_post(self.sync.blink, url)
+        server = response["server"]
+        server_split = server.split(":")
+        server_split[0] = "rtsps:"
+        link = "".join(server_split)
+        return link

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -11,7 +11,7 @@ from unittest import mock
 from blinkpy.blinkpy import Blink
 from blinkpy.helpers.util import BlinkURLHandler
 from blinkpy.sync_module import BlinkSyncModule
-from blinkpy.camera import BlinkCamera, BlinkCameraMini
+from blinkpy.camera import BlinkCamera, BlinkCameraMini, BlinkDoorbell
 
 
 CAMERA_CFG = {
@@ -177,9 +177,20 @@ class TestBlinkCameraSetup(unittest.TestCase):
         for key in attr:
             self.assertEqual(attr[key], None)
 
+    def test_doorbell_missing_attributes(self, mock_resp):
+        """Test that attributes return None if missing."""
+        camera = BlinkDoorbell(self.blink.sync)
+        self.blink.sync.network_id = None
+        self.blink.sync.name = None
+        attr = camera.attributes
+        for key in attr:
+            self.assertEqual(attr[key], None)
+
     def test_camera_stream(self, mock_resp):
         """Test that camera stream returns correct url."""
         mock_resp.return_value = {"server": "rtsps://foo.bar"}
         mini_camera = BlinkCameraMini(self.blink.sync["test"])
+        doorbell_camera = BlinkDoorbell(self.blink.sync["test"])
         self.assertEqual(self.camera.get_liveview(), "rtsps://foo.bar")
         self.assertEqual(mini_camera.get_liveview(), "rtsps://foo.bar")
+        self.assertEqual(doorbell_camera.get_liveview(), "rtsps://foo.bar")

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -4,8 +4,8 @@ from unittest import mock
 
 from blinkpy.blinkpy import Blink
 from blinkpy.helpers.util import BlinkURLHandler
-from blinkpy.sync_module import BlinkSyncModule, BlinkOwl
-from blinkpy.camera import BlinkCamera, BlinkCameraMini
+from blinkpy.sync_module import BlinkSyncModule, BlinkOwl, BlinkLotus
+from blinkpy.camera import BlinkCamera, BlinkCameraMini, BlinkDoorbell
 
 
 @mock.patch("blinkpy.auth.Auth.query")
@@ -292,3 +292,20 @@ class TestBlinkSyncModule(unittest.TestCase):
         self.assertTrue(owl.start())
         self.assertTrue("foo" in owl.cameras)
         self.assertEqual(owl.cameras["foo"].__class__, BlinkCameraMini)
+
+    def test_lotus_start(self, mock_resp):
+        """Test doorbell instantiation."""
+        response = {
+            "name": "doo",
+            "id": 3,
+            "serial": "doobar123",
+            "enabled": True,
+            "network_id": 1,
+            "thumbnail": "/foo/bar",
+        }
+        self.blink.last_refresh = None
+        self.blink.homescreen = {"doorbells": [response]}
+        lotus = BlinkLotus(self.blink, "doo", 1234, response)
+        self.assertTrue(lotus.start())
+        self.assertTrue("doo" in lotus.cameras)
+        self.assertEqual(lotus.cameras["doo"].__class__, BlinkDoorbell)


### PR DESCRIPTION
## Description:

Add support for Blink Doorbells so home assistant can use them.  This PR adds doorbells to the camera list and also enables snapshots and streams for the doorbells.

**Related issue (if applicable):** fixes #514 

## Checklist:
- [X] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [X] Changes tested locally to ensure platform still works as intended
- [X] Tests added to verify new code works. (Could use one more test completed in test_blinkpy.py lines 330-357)
