### PR TITLE
fix debug message in _parse_downloaded_items

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -385,7 +385,7 @@ class Blink:
                 print(
                     (
                         f"Camera: {camera_name}, Timestamp: {created_at}, "
-                        "Address: {address}, Filename: {filename}"
+                        f"Address: {address}, Filename: {filename}"
                     )
                 )
             if delay > 0:


### PR DESCRIPTION
## Description:
Hi while doing some debugging to download latest available video I found out a missing character :slightly_smiling_face: 

before PR
```Camera: Jardin, Timestamp: 2022-01-22T11:13:51+00:00, Address: {address}, Filename: {filename}```

with fix:
```Camera: Jardin, Timestamp: 2022-01-22T11:13:51+00:00, Address: /api/v2/accounts/xxxxx/media/clip/yyyyyy.mp4, Filename: /tmp/jardin-2022-01-22t11-13-51-00-00.mp4```

Cheers

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
