### PR TITLE
Use urljoin to create thumbnail string

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -2,9 +2,10 @@
 
 from shutil import copyfileobj
 import logging
+from json import dumps
+from requests.compat import urljoin
 from blinkpy import api
 from blinkpy.helpers.constants import TIMEOUT_MEDIA
-from json import dumps
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -168,7 +169,7 @@ class BlinkCamera:
             _LOGGER.warning("Could not find thumbnail for camera %s", self.name)
 
         if thumb_addr is not None:
-            new_thumbnail = f"{self.sync.urls.base_url}{thumb_addr}.jpg"
+            new_thumbnail = urljoin(self.sync.urls.base_url, f"{thumb_addr}.jpg")
 
         try:
             self.motion_detected = self.sync.motion[self.name]

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -87,6 +87,14 @@ class TestBlinkCameraSetup(unittest.TestCase):
         self.assertEqual(self.camera.image_from_cache, "test")
         self.assertEqual(self.camera.video_from_cache, "foobar")
 
+        # Check that thumbnail without slash processed properly
+        mock_resp.side_effect = [None]
+        self.camera.update_images({"thumbnail": "thumb_no_slash"})
+        self.assertEqual(
+            self.camera.thumbnail,
+            "https://rest-test.immedia-semi.com/thumb_no_slash.jpg",
+        )
+
     def test_no_thumbnails(self, mock_resp):
         """Tests that thumbnail is 'None' if none found."""
         mock_resp.return_value = "foobar"


### PR DESCRIPTION
## Description:
Uses urljoin function from requests lib to always parse thumbnails correctly.

Note: my system doesn't have the problems in the linked issue, so I cannot be certain it fixed the problem

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/67481

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ ] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
