### PR TITLE
Fix getting doorbell details

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -150,7 +150,7 @@ class BlinkCamera:
         self.serial = config.get("serial", None)
         self.motion_enabled = config.get("enabled", "unknown")
         self.battery_voltage = config.get("battery_voltage", None)
-        self.battery_state = config.get("battery_state", None)
+        self.battery_state = config.get("battery_state", None) or config.get("battery", None)
         self.temperature = config.get("temperature", None)
         self.wifi_strength = config.get("wifi_strength", None)
         self.product_type = config.get("type", None)

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -150,7 +150,9 @@ class BlinkCamera:
         self.serial = config.get("serial", None)
         self.motion_enabled = config.get("enabled", "unknown")
         self.battery_voltage = config.get("battery_voltage", None)
-        self.battery_state = config.get("battery_state", None) or config.get("battery", None)
+        self.battery_state = config.get("battery_state", None) or config.get(
+            "battery", None
+        )
         self.temperature = config.get("temperature", None)
         self.wifi_strength = config.get("wifi_strength", None)
         self.product_type = config.get("type", None)

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -124,7 +124,7 @@ class BlinkSyncModule:
         """Update cameras from server."""
         type_map = {
             "mini": BlinkCameraMini,
-            "doorbell": BlinkDoorbell,
+            "lotus": BlinkDoorbell,
         }
         try:
             for camera_config in self.camera_list:

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -39,7 +39,7 @@ class BlinkSyncModule:
         self.available = False
         self.type_key_map = {
             "mini": "owls",
-            "lotus": "doorbell",
+            "lotus": "doorbells",
         }
 
     @property
@@ -124,7 +124,7 @@ class BlinkSyncModule:
         """Update cameras from server."""
         type_map = {
             "mini": BlinkCameraMini,
-            "lotus": BlinkDoorbell,
+            "doorbell": BlinkDoorbell,
         }
         try:
             for camera_config in self.camera_list:


### PR DESCRIPTION
## Description:
Doorbell information in HASS was not populating properly.  On closer inspection in `blinkpy` the doorbell was being identified as a camera.  This led to a number of errors and warnings in the HASS log.

![image](https://user-images.githubusercontent.com/8431065/173072225-23c4ba45-353c-4ffd-9ac3-d0e66e9040e6.png)

The HASS developer tools showed this...

![image](https://user-images.githubusercontent.com/8431065/173072310-4c7ee1aa-7221-4c02-8d0b-42eaca21d5e6.png)

This change addresses type identification and ensures that battery details are extracted as well.

![image](https://user-images.githubusercontent.com/8431065/173072480-0d33c4e9-68cf-4e6d-a6fd-0b45a291e892.png)

I've tested this locally to ensure that the `blinkpy` library continues to work - seems to.  I've also adjusted the files in use by HASS to ensure that the data is represented as expected.

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [X] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
