### PR TITLE
Fix inclusion

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -221,7 +221,7 @@ class Blink:
                     all_cameras[camera_network] = []
                 for camera in network["cameras"]:
                     all_cameras[camera_network].append(
-                        {"name": camera["name"], "id": camera["id"]}
+                        {"name": camera["name"], "id": camera["id"], "type": "default"}
                     )
             mini_cameras = self.setup_owls()
             lotus_cameras = self.setup_lotus()

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -125,6 +125,7 @@ class BlinkSyncModule:
         type_map = {
             "mini": BlinkCameraMini,
             "lotus": BlinkDoorbell,
+            "default": BlinkCamera,
         }
         try:
             for camera_config in self.camera_list:

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -103,8 +103,11 @@ class TestBlinkSetup(unittest.TestCase):
         self.assertEqual(
             result,
             {
-                "1234": [{"name": "foo", "id": 5678}, {"name": "bar", "id": 5679}],
-                "4321": [{"name": "test", "id": 0000}],
+                "1234": [
+                    {"name": "foo", "id": 5678, "type": "default"},
+                    {"name": "bar", "id": 5679, "type": "default"},
+                ],
+                "4321": [{"name": "test", "id": 0000, "type": "default"}],
             },
         )
 
@@ -483,7 +486,7 @@ class TestBlinkSetup(unittest.TestCase):
                 {"name": "bar", "id": "1234", "type": "doorbell"},
                 {"name": "dead", "id": "1234", "type": "mini"},
                 {"name": "beef", "id": "1234", "type": "mini"},
-                {"name": "normal", "id": "1234"},
+                {"name": "normal", "id": "1234", "type": "default"},
             ]
         }
         mock_usage.return_value = {

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -373,3 +373,15 @@ class TestBlinkSyncModule(unittest.TestCase):
             self.assertEqual(
                 test_sync.cameras["fake"].__class__, BlinkDoorbell, msg=debug_msg
             )
+
+    def test_name_not_in_config(self, mock_resp):
+        """Check that function exits when name not in camera_config."""
+        test_sync = self.blink.sync["test"]
+        test_sync.camera_list = [{"foo": "bar"}]
+        self.assertTrue(test_sync.update_cameras())
+
+    def test_camera_config_key_error(self, mock_resp):
+        """Check that update returns False on KeyError."""
+        test_sync = self.blink.sync["test"]
+        test_sync.camera_list = [{"name": "foobar"}]
+        self.assertFalse(test_sync.update_cameras())


### PR DESCRIPTION
## Description:
If a single sync module has a mix of camera type attached (any combo of normal, doorbell, mini), the `type` property would retain the previous state. Some tests were added to check for this as well as a small code modification. It may not fix any problems, but should be the routine more robust anyhow.

**Related issue (if applicable):** Possibly impacts #580 , TBD

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
