### PR TITLE
Fix doorbell mapping

### DIFF
--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -124,7 +124,7 @@ class BlinkSyncModule:
         """Update cameras from server."""
         type_map = {
             "mini": BlinkCameraMini,
-            "lotus": BlinkDoorbell,
+            "doorbell": BlinkDoorbell,
             "default": BlinkCamera,
         }
         try:

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -39,7 +39,7 @@ class BlinkSyncModule:
         self.available = False
         self.type_key_map = {
             "mini": "owls",
-            "lotus": "doorbells",
+            "doorbell": "doorbells",
         }
 
     @property

--- a/tests/test_sync_functions.py
+++ b/tests/test_sync_functions.py
@@ -170,7 +170,7 @@ class TestBlinkSyncModule(unittest.TestCase):
         self.blink.sync["test"].camera_list = [
             {"name": "foo", "id": 10, "type": "default"},
             {"name": "bar", "id": 11, "type": "mini"},
-            {"name": "fake", "id": 12, "type": "lotus"},
+            {"name": "fake", "id": 12, "type": "doorbell"},
         ]
 
         self.blink.homescreen = {


### PR DESCRIPTION
Apologies.  I missed this when submitting the last PR but had it locally for some reason.  Without the change the device seems to work but gets identified as a mini and then incorrect end points are used.

## Description:


**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ ] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
