### PR TITLE
Fix the errors for the Blink doorbell camera

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -323,7 +323,7 @@ class BlinkDoorbell(BlinkCamera):
 
     def snap_picture(self):
         """Snap picture for a blink doorbell camera."""
-        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.network_id}/lotus/{self.camera_id}/thumbnail"
+        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.network_id}/doorbells/{self.camera_id}/thumbnail"
         return api.http_post(self.sync.blink, url)
 
     def get_sensor_info(self):
@@ -331,7 +331,7 @@ class BlinkDoorbell(BlinkCamera):
 
     def get_liveview(self):
         """Get liveview link."""
-        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.network_id}/lotus/{self.camera_id}/liveview"
+        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.network_id}/doorbells/{self.camera_id}/liveview"
         response = api.http_post(self.sync.blink, url)
         server = response["server"]
         server_split = server.split(":")


### PR DESCRIPTION
## Description:

The Blink API changed the endpoint from lotus to doorbells for the
doorbell cameras. This was found by decompiling the Android APK and
looking at the path for the API call. This affects both the
snap_picture and get_liveview methods.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be merged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
