### PR TITLE
Misc doorbell fixes

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -334,7 +334,5 @@ class BlinkDoorbell(BlinkCamera):
         url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.network_id}/doorbells/{self.camera_id}/liveview"
         response = api.http_post(self.sync.blink, url)
         server = response["server"]
-        server_split = server.split(":")
-        server_split[0] = "rtsps:"
-        link = "".join(server_split)
+        link = server.replace("immis://", "rtsps://")
         return link

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -323,7 +323,7 @@ class BlinkDoorbell(BlinkCamera):
 
     def snap_picture(self):
         """Snap picture for a blink doorbell camera."""
-        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.network_id}/doorbells/{self.camera_id}/thumbnail"
+        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.sync.network_id}/doorbells/{self.camera_id}/thumbnail"
         return api.http_post(self.sync.blink, url)
 
     def get_sensor_info(self):
@@ -331,7 +331,7 @@ class BlinkDoorbell(BlinkCamera):
 
     def get_liveview(self):
         """Get liveview link."""
-        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.network_id}/doorbells/{self.camera_id}/liveview"
+        url = f"{self.sync.urls.base_url}/api/v1/accounts/{self.sync.blink.account_id}/networks/{self.sync.network_id}/doorbells/{self.camera_id}/liveview"
         response = api.http_post(self.sync.blink, url)
         server = response["server"]
         link = server.replace("immis://", "rtsps://")


### PR DESCRIPTION
## Description:

1. Network ID for doorbell accessed via sync object
2. String split and join for protocol replacement swallows the port colo (i.e. "immis://host:port/path" changes to "rtsps://hostport/path") so use a more explicit replacement instead.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
