### PR TITLE
IR Toggle to toggle infrared illumination 

### DIFF
--- a/blinkpy/helpers/camera.py
+++ b/blinkpy/helpers/camera.py
@@ -23,9 +23,10 @@ def set_night_vision(camera, to="auto"):
     Set night vision (IR) parameters for a Blink camera.
 
     :to: new state for the IR illuminator.
-         Owl cameras accept "on", "off", and "auto" states,
-         whereas Catalina cameras accept 0, 1, or 2 as valid states.
+         Possible states are 'on', 'off', and 'auto'
     """
+    if camera.product_type == "catalina":
+        to = {"off": 0, "on": 1, "auto": 2}.get(to, None)
     if camera.product_type == "owl" and to in ["auto", "on", "off"]:
         url = f"{camera.sync.urls.base_url}/api/v1/accounts/{camera.sync.blink.account_id}/networks/{camera.network_id}/owls/{camera.camera_id}/config"
     elif camera.product_type == "catalina" and to in [0, 1, 2]:

--- a/blinkpy/helpers/camera.py
+++ b/blinkpy/helpers/camera.py
@@ -1,0 +1,37 @@
+from json import dumps
+from blinkpy import api
+
+
+def get_night_vision_info(camera):
+    """Get `night_vision_control` info"""
+    if camera.product_type == "owl":
+        url = f"{camera.sync.urls.base_url}/api/v1/accounts/{camera.sync.blink.account_id}/networks/{camera.network_id}/owls/{camera.camera_id}/config"
+        res = api.http_get(camera.sync.blink, url)
+    elif camera.product_type == "catalina":
+        url = f"{camera.sync.urls.base_url}/network/{camera.network_id}/camera/{camera.camera_id}/config"
+        res = api.http_get(camera.sync.blink, url).get("camera", [{}])[0]
+    else:
+        return None
+    keys = ["night_vision_control", "illuminator_enable", "illuminator_enable_v2"]
+    return dict(zip(keys, map(lambda _: res.get(_, None), keys)))
+
+
+def set_night_vision(camera, to="auto"):
+    """
+    Set night vision (IR) parameters for a Blink camera
+
+    :to: new state for the IR illuminator. 
+         Owl cameras accept "on", "off", and "auto" states,
+         whereas Catalina cameras accept 0, 1, or 2 as valid states.
+    """
+    if camera.product_type == "owl" and to in ["auto", "on", "off"]:
+        url = f"{camera.sync.urls.base_url}/api/v1/accounts/{camera.sync.blink.account_id}/networks/{camera.network_id}/owls/{camera.camera_id}/config"
+    elif camera.product_type == "catalina" and to in [0, 1, 2]:
+        url = f"{camera.sync.urls.base_url}/network/{camera.network_id}/camera/{camera.camera_id}/update"
+    else:
+        return None
+    data = dumps({"illuminator_enable": to})
+    res = api.http_post(camera.sync.blink, url, json=False, data=data)
+    if res.ok:
+        return res.json()
+    return None

--- a/blinkpy/helpers/camera.py
+++ b/blinkpy/helpers/camera.py
@@ -1,9 +1,11 @@
+"""Provide functions for enabling infrared illumiation."""
+
 from json import dumps
 from blinkpy import api
 
 
 def get_night_vision_info(camera):
-    """Get `night_vision_control` info"""
+    """Get `night_vision_control` info."""
     if camera.product_type == "owl":
         url = f"{camera.sync.urls.base_url}/api/v1/accounts/{camera.sync.blink.account_id}/networks/{camera.network_id}/owls/{camera.camera_id}/config"
         res = api.http_get(camera.sync.blink, url)
@@ -18,9 +20,9 @@ def get_night_vision_info(camera):
 
 def set_night_vision(camera, to="auto"):
     """
-    Set night vision (IR) parameters for a Blink camera
+    Set night vision (IR) parameters for a Blink camera.
 
-    :to: new state for the IR illuminator. 
+    :to: new state for the IR illuminator.
          Owl cameras accept "on", "off", and "auto" states,
          whereas Catalina cameras accept 0, 1, or 2 as valid states.
     """

--- a/helpers.md
+++ b/helpers.md
@@ -1,0 +1,16 @@
+# Helper Functions
+
+## IR/ Night Vision settings
+
+There are helper functions that provide the ability to turn on and off the IR illuminator on Blink cameras. This allows for capturing IR images when needed.
+
+```py
+from blinkpy.helpers import camera
+
+# Assume `test_cam` is a valid BlinkCamera object
+# Get the current IR status.
+camera.get_night_vision_info(test_cam)
+
+# Change the IR light
+camera.set_night_vision(test_cam, "off")
+```


### PR DESCRIPTION
## Description:

Solved #639

Adds features for Blink Mini and Blink Wireless (tested) to enable infrared illumination in the form of helper functions.

## Checklist:
- [x ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
