### PR TITLE
Deprecate py3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         platform:
           - ubuntu-latest
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -8,7 +8,7 @@ PATCH_VERSION = "0.dev0"
 
 __version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}"
 
-REQUIRED_PYTHON_VER = (3, 7, 0)
+REQUIRED_PYTHON_VER = (3, 8, 0)
 
 PROJECT_NAME = "blinkpy"
 PROJECT_PACKAGE_NAME = "blinkpy"
@@ -31,7 +31,6 @@ PROJECT_CLASSIFIERS = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Description:
Minimum version now Python 3.8
