### PR TITLE
adding get_videos_metadata

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -334,7 +334,7 @@ class Blink:
         if not isinstance(camera, list):
             camera = [camera]
 
-        results = self.get_videos_metadata(since, stop)
+        results = self.get_videos_metadata(since=since, stop=stop)
         self._parse_downloaded_items(results, camera, path, delay, debug)
 
     def get_videos_metadata(

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -336,9 +336,7 @@ class Blink:
         results = self.get_videos_metadata(since=since, stop=stop)
         self._parse_downloaded_items(results, camera, path, delay, debug)
 
-    def get_videos_metadata(
-        self, since=None, camera="all", stop=10
-    ):
+    def get_videos_metadata(self, since=None, camera="all", stop=10):
         """
         Fetch and return video metadata.
 

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -330,6 +330,25 @@ class Blink:
         :param debug: Set to TRUE to prevent downloading of items.
                       Instead of downloading, entries will be printed to log.
         """
+
+        if not isinstance(camera, list):
+            camera = [camera]
+
+        results = self.get_videos_metadata(since, stop)
+        self._parse_downloaded_items(results, camera, path, delay, debug)
+
+    def get_videos_metadata(
+        self, since=None, camera="all", stop=10
+    ):
+        """
+        Fetch and return video metadata
+
+        :param since: Date and time to get videos from.
+                      Ex: "2018/07/28 12:33:00" to retrieve videos since
+                      July 28th 2018 at 12:33:00
+        :param stop: Page to stop on (~25 items per page. Default page 10).
+        """
+        videos = []
         if since is None:
             since_epochs = self.last_refresh
         else:
@@ -339,9 +358,6 @@ class Blink:
         formatted_date = util.get_time(time_to_convert=since_epochs)
         _LOGGER.info("Retrieving videos since %s", formatted_date)
 
-        if not isinstance(camera, list):
-            camera = [camera]
-
         for page in range(1, stop):
             response = api.request_videos(self, time=since_epochs, page=page)
             _LOGGER.debug("Processing page %s", page)
@@ -349,11 +365,21 @@ class Blink:
                 result = response["media"]
                 if not result:
                     raise KeyError
+                videos.extend(result)
             except (KeyError, TypeError):
                 _LOGGER.info("No videos found on page %s. Exiting.", page)
                 break
+        return videos
 
-            self._parse_downloaded_items(result, camera, path, delay, debug)
+    def do_http_get(self, address):
+        response = api.http_get(
+            self,
+            url=f"{self.urls.base_url}{address}",
+            stream=True,
+            json=False,
+            timeout=TIMEOUT_MEDIA,
+        )
+        return response
 
     def _parse_downloaded_items(self, result, camera, path, delay, debug):
         """Parse downloaded videos."""
@@ -375,7 +401,6 @@ class Blink:
                 _LOGGER.debug("%s: %s is marked as deleted.", camera_name, address)
                 continue
 
-            clip_address = f"{self.urls.base_url}{address}"
             filename = f"{camera_name}-{created_at}"
             filename = f"{slugify(filename)}.mp4"
             filename = os.path.join(path, filename)
@@ -385,13 +410,7 @@ class Blink:
                     _LOGGER.info("%s already exists, skipping...", filename)
                     continue
 
-                response = api.http_get(
-                    self,
-                    url=clip_address,
-                    stream=True,
-                    json=False,
-                    timeout=TIMEOUT_MEDIA,
-                )
+                response = self.do_http_get(address)
                 with open(filename, "wb") as vidfile:
                     copyfileobj(response.raw, vidfile)
 

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -330,7 +330,6 @@ class Blink:
         :param debug: Set to TRUE to prevent downloading of items.
                       Instead of downloading, entries will be printed to log.
         """
-
         if not isinstance(camera, list):
             camera = [camera]
 

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -341,7 +341,7 @@ class Blink:
         self, since=None, camera="all", stop=10
     ):
         """
-        Fetch and return video metadata
+        Fetch and return video metadata.
 
         :param since: Date and time to get videos from.
                       Ex: "2018/07/28 12:33:00" to retrieve videos since
@@ -372,6 +372,11 @@ class Blink:
         return videos
 
     def do_http_get(self, address):
+        """
+        Do an http_get on address.
+
+        :param address: address to be added to base_url.
+        """
         response = api.http_get(
             self,
             url=f"{self.urls.base_url}{address}",

--- a/tests/test_blink_functions.py
+++ b/tests/test_blink_functions.py
@@ -9,6 +9,7 @@ from blinkpy.sync_module import BlinkSyncModule
 from blinkpy.camera import BlinkCamera
 from blinkpy.helpers.util import get_time, BlinkURLHandler
 
+from requests import Response
 
 class MockSyncModule(BlinkSyncModule):
     """Mock blink sync module object."""
@@ -116,6 +117,36 @@ class TestBlinkFunctions(unittest.TestCase):
         now = time.time()
         delta = now - start
         self.assertTrue(delta >= 0.1)
+
+    @mock.patch("blinkpy.blinkpy.api.request_videos")
+    def test_get_videos_metadata(self, mock_req):
+        """Test ability to fetch videos metadata."""
+        blink = blinkpy.Blink()
+        generic_entry = {
+            "created_at": "1970",
+            "device_name": "foo",
+            "deleted": True,
+            "media": "/bar.mp4",
+        }
+        result = [generic_entry]
+        mock_req.return_value = {"media": result}
+        blink.last_refresh = 0
+        formatted_date = get_time(blink.last_refresh)
+
+        results = blink.get_videos_metadata(stop=2)
+        expected_results = [ {'created_at': '1970', 'device_name': 'foo', 'deleted': True, 'media': '/bar.mp4'} ]
+        self.assertListEqual(results, expected_results)
+
+
+    @mock.patch("blinkpy.blinkpy.api.http_get")
+    def test_do_http_get(self, mock_req):
+        """Test ability to do_http_get."""
+        blink = blinkpy.Blink()
+        blink.urls = BlinkURLHandler("test")
+
+        mock_req.return_value = Response()
+        response = blink.do_http_get('/path/to/request')
+        self.assertTrue(response != None)
 
     @mock.patch("blinkpy.blinkpy.api.request_videos")
     def test_parse_camera_not_in_list(self, mock_req):

--- a/tests/test_blink_functions.py
+++ b/tests/test_blink_functions.py
@@ -134,7 +134,14 @@ class TestBlinkFunctions(unittest.TestCase):
         blink.last_refresh = 0
 
         results = blink.get_videos_metadata(stop=2)
-        expected_results = [{'created_at': '1970', 'device_name': 'foo', 'deleted': True, 'media': '/bar.mp4'}]
+        expected_results = [
+            {
+                'created_at': '1970',
+                'device_name': 'foo',
+                'deleted': True,
+                'media': '/bar.mp4'
+            }
+        ]
         self.assertListEqual(results, expected_results)
 
     @mock.patch("blinkpy.blinkpy.api.http_get")
@@ -144,7 +151,7 @@ class TestBlinkFunctions(unittest.TestCase):
         blink.urls = BlinkURLHandler("test")
 
         mock_req.return_value = Response()
-        response = blink.do_http_get('/path/to/request')
+        response = blink.do_http_get("/path/to/request")
         self.assertTrue(response is not None)
 
     @mock.patch("blinkpy.blinkpy.api.request_videos")

--- a/tests/test_blink_functions.py
+++ b/tests/test_blink_functions.py
@@ -11,6 +11,7 @@ from blinkpy.helpers.util import get_time, BlinkURLHandler
 
 from requests import Response
 
+
 class MockSyncModule(BlinkSyncModule):
     """Mock blink sync module object."""
 
@@ -131,12 +132,10 @@ class TestBlinkFunctions(unittest.TestCase):
         result = [generic_entry]
         mock_req.return_value = {"media": result}
         blink.last_refresh = 0
-        formatted_date = get_time(blink.last_refresh)
 
         results = blink.get_videos_metadata(stop=2)
-        expected_results = [ {'created_at': '1970', 'device_name': 'foo', 'deleted': True, 'media': '/bar.mp4'} ]
+        expected_results = [{'created_at': '1970', 'device_name': 'foo', 'deleted': True, 'media': '/bar.mp4'}]
         self.assertListEqual(results, expected_results)
-
 
     @mock.patch("blinkpy.blinkpy.api.http_get")
     def test_do_http_get(self, mock_req):
@@ -146,7 +145,7 @@ class TestBlinkFunctions(unittest.TestCase):
 
         mock_req.return_value = Response()
         response = blink.do_http_get('/path/to/request')
-        self.assertTrue(response != None)
+        self.assertTrue(response is not None)
 
     @mock.patch("blinkpy.blinkpy.api.request_videos")
     def test_parse_camera_not_in_list(self, mock_req):

--- a/tests/test_blink_functions.py
+++ b/tests/test_blink_functions.py
@@ -136,10 +136,10 @@ class TestBlinkFunctions(unittest.TestCase):
         results = blink.get_videos_metadata(stop=2)
         expected_results = [
             {
-                'created_at': '1970',
-                'device_name': 'foo',
-                'deleted': True,
-                'media': '/bar.mp4'
+                "created_at": "1970",
+                "device_name": "foo",
+                "deleted": True,
+                "media": "/bar.mp4",
             }
         ]
         self.assertListEqual(results, expected_results)


### PR DESCRIPTION
## Description:

I have a micro-service which I have been using to get blink camera armed and battery status.  I'd like to add to that micro-service the ability to 1. list videos, and 2. download videos.  I checked, and download_videos had the components I was looking for, but they were all wrapped up together.  With this PR I'm breaking out two methods: 1. get_videos_metadata, and 2. do_http_get.  The download_videos now consists of 1. forcing `camera` into a list, a call to get_videos_metadata, and then calling the download parser.  The download parser was only modified to call do_http_get instead of downloading directly, and moving the calculation of clip_address into do_http_get. 

**Related issue (if applicable):** N/A

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
```
➜  blinkpy git:(videos-metadata) ✗ python -m tox -e py38          
...
Results (0.79s):
     107 passed
  py38: OK (1.22=setup[0.07]+cmd[1.15] seconds)
  congratulations :) (1.32 seconds)
```
- [x] Changes tested locally to ensure platform still works as intended
```
### I changed download dir in blinkapp.py to /tmp for my local testing
➜  blinkpy git:(videos-metadata) ✗ python3 -m pip install ./ && CREDFILE=./creds.json python3 blinkapp/blinkapp.py                      
...
➜  blinkpy git:(videos-metadata) ✗ ls -al /tmp/*.mp4  
-rw-rw-r-- 1 rhh rhh  158028 Feb  4 16:18 /tmp/front-door-2023-02-02t20-30-53-00-00.mp4
-rw-rw-r-- 1 rhh rhh  935551 Feb  4 16:18 /tmp/front-door-2023-02-02t23-32-10-00-00.mp4
...
-rw-rw-r-- 1 rhh rhh  456354 Feb  4 16:17 /tmp/garage-ext-2023-02-04t15-01-36-00-00.mp4
-rw-rw-r-- 1 rhh rhh  976975 Feb  4 16:17 /tmp/garage-ext-2023-02-04t15-31-06-00-00.mp4
```
- [x] Tests added to verify new code works
