### PR TITLE
Add wait for command to all PUT methods

### DIFF
--- a/tests/mock_responses.py
+++ b/tests/mock_responses.py
@@ -17,3 +17,7 @@ class MockResponse:
     async def json(self):
         """Return json data from get_request."""
         return self.json_data
+
+    def get(self, name):
+        """Return field for json."""
+        return self.json_data[name]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,10 @@ from blinkpy.blinkpy import Blink, util
 from blinkpy.auth import Auth
 import tests.mock_responses as mresp
 
+COMMAND_RESPONSE = {"network_id": "12345", "id": "54321"}
+COMMAND_COMPLETE = {"complete": True, "status_code": 908}
+COMMAND_NOT_COMPLETE = {"complete": False, "status_code": 908}
+
 
 @mock.patch("blinkpy.auth.Auth.query")
 class TestAPI(IsolatedAsyncioTestCase):
@@ -57,7 +61,7 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_command_status(self, mock_resp):
         """Test command_status."""
-        mock_resp.return_value = {"command": "done"}
+        mock_resp.side_effect = ({"command": "done"}, COMMAND_COMPLETE)
         self.assertEqual(
             await api.request_command_status(self.blink, "network", "command"),
             {"command": "done"},
@@ -65,13 +69,19 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_new_image(self, mock_resp):
         """Test api request new image."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_new_image(self.blink, "network", "camera")
         self.assertEqual(response.status, 200)
 
     async def test_request_new_video(self, mock_resp):
         """Test api request new Video."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_new_video(self.blink, "network", "camera")
         self.assertEqual(response.status, 200)
 
@@ -97,7 +107,10 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_motion_detection_enable(self, mock_resp):
         """Test  Motion detect enable."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_motion_detection_enable(
             self.blink, "network", "camera"
         )
@@ -105,7 +118,10 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_motion_detection_disable(self, mock_resp):
         """Test  Motion detect enable."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_motion_detection_disable(
             self.blink, "network", "camera"
         )
@@ -113,7 +129,10 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_local_storage_clip(self, mock_resp):
         """Test Motion detect enable."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_local_storage_clip(
             self.blink, "network", "sync_id", "manifest_id", "clip_id"
         )
@@ -135,7 +154,7 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_update_config(self, mock_resp):
         """Test Motion detect enable."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.return_value = mresp.MockResponse(COMMAND_RESPONSE, 200)
         response = await api.request_update_config(
             self.blink, "network", "camera_id", "owl"
         )
@@ -149,3 +168,13 @@ class TestAPI(IsolatedAsyncioTestCase):
                 self.blink, "network", "camera_id", "other_camera"
             )
         )
+
+    async def test_wait_for_command(self, mock_resp):
+        """Test Motion detect enable."""
+        mock_resp.side_effect = (COMMAND_NOT_COMPLETE, COMMAND_COMPLETE)
+        response = await api.wait_for_command(self.blink, COMMAND_RESPONSE)
+        assert response
+
+        mock_resp.side_effect = (COMMAND_NOT_COMPLETE, {})
+        response = await api.wait_for_command(self.blink, COMMAND_RESPONSE)
+        self.assertFalse(response)

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -26,6 +26,10 @@ CAMERA_CFG = {
     ]
 }
 
+COMMAND_RESPONSE = {"network_id": "12345", "id": "54321"}
+COMMAND_COMPLETE = {"complete": True, "status_code": 908}
+COMMAND_NOT_COMPLETE = {"complete": False, "status_code": 908}
+
 
 @mock.patch("blinkpy.auth.Auth.query")
 class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
@@ -154,7 +158,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         mock_resp.return_value = mresp.MockResponse({"test": 200}, 200, raw_data="")
         self.camera.sync.homescreen = {"devices": []}
         await self.camera.update(config, force_cache=True, expire_clips=False)
-        self.assertEqual(self.camera.clip, None)
+        self.assertEqual(self.camera.clip, "")
         self.assertEqual(self.camera.video_from_cache, None)
 
     async def test_recent_video_clips(self, mock_resp):

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -98,11 +98,11 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         self.blink.sync.network_id = None
         self.blink.sync.name = None
         attr = camera.attributes
-        for key in attr:
+        for key, value in attr.items():
             if key == "recent_clips":
-                self.assertEqual(attr[key], [])
+                self.assertEqual(value, [])
                 continue
-            self.assertEqual(attr[key], None)
+            self.assertIn(value, ("", None, False))
 
     def test_doorbell_missing_attributes(self, mock_resp):
         """Test that attributes return None if missing."""
@@ -110,11 +110,11 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         self.blink.sync.network_id = None
         self.blink.sync.name = None
         attr = camera.attributes
-        for key in attr:
+        for key, value in attr.items():
             if key == "recent_clips":
-                self.assertEqual(attr[key], [])
+                self.assertEqual(value, [])
                 continue
-            self.assertEqual(attr[key], None)
+            self.assertIn(value, ("", None, False))
 
     async def test_camera_stream(self, mock_resp):
         """Test that camera stream returns correct url."""


### PR DESCRIPTION
## Description:
While researching the event API, I discovered the Android app polls the command status to determine when to get the results.  This improves the performance quite a bit as we don't have to wait for the last backoff (some times 24 seconds).

All PUT methods receive a response code with the command id and network id.  Polling at 1 second (same as the app) until it receives a complete.
If any of the keys are missing, the API will fall back to the previous retry method.


**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
