### PR TITLE
Fix blinkapp session call

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/blinkapp/blinkapp.py
+++ b/blinkapp/blinkapp.py
@@ -24,7 +24,7 @@ async def download_videos(blink, save_dir="/media"):
 async def start(session: ClientSession):
     """Startup blink app."""
     blink = Blink(session=session)
-    blink.auth = Auth(await json_load(CREDFILE))
+    blink.auth = Auth(await json_load(CREDFILE), session=session)
     await blink.start()
     return blink
 

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -501,8 +501,8 @@ async def wait_for_command(blink, json_data: dict) -> bool:
             _LOGGER.debug("Making GET request waiting for command")
             status = await request_command_status(blink, network_id, command_id)
             _LOGGER.debug("command status %s", status)
-            if status.get("complete"):
-                return True
             if status.get("status_code", 0) != 908:
                 return False
+            if status.get("complete"):
+                return True
             await sleep(COMMAND_POLL_TIME)

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -3,6 +3,7 @@
 import logging
 import string
 from json import dumps
+from asyncio import sleep
 from blinkpy.helpers.util import (
     get_time,
     Throttle,
@@ -13,6 +14,7 @@ from blinkpy.helpers.constants import DEFAULT_URL, TIMEOUT, DEFAULT_USER_AGENT
 _LOGGER = logging.getLogger(__name__)
 
 MIN_THROTTLE_TIME = 5
+COMMAND_POLL_TIME = 1
 
 
 async def request_login(
@@ -94,7 +96,9 @@ async def request_network_update(blink, network):
     :param network: Sync module network id.
     """
     url = f"{blink.urls.base_url}/network/{network}/update"
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 async def request_user(blink):
@@ -137,7 +141,9 @@ async def request_system_arm(blink, network):
         f"{blink.urls.base_url}/api/v1/accounts/{blink.account_id}"
         f"/networks/{network}/state/arm"
     )
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
@@ -152,7 +158,9 @@ async def request_system_disarm(blink, network):
         f"{blink.urls.base_url}/api/v1/accounts/{blink.account_id}"
         f"/networks/{network}/state/disarm"
     )
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 async def request_command_status(blink, network, command_id):
@@ -196,7 +204,9 @@ async def request_new_image(blink, network, camera_id):
     :param camera_id: Camera ID of camera to request new image from.
     """
     url = f"{blink.urls.base_url}/network/{network}/camera/{camera_id}/thumbnail"
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
@@ -209,7 +219,9 @@ async def request_new_video(blink, network, camera_id):
     :param camera_id: Camera ID of camera to request new video from.
     """
     url = f"{blink.urls.base_url}/network/{network}/camera/{camera_id}/clip"
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
@@ -280,7 +292,9 @@ async def request_camera_liveview(blink, network, camera_id):
         f"{blink.urls.base_url}/api/v5/accounts/{blink.account_id}"
         f"/networks/{network}/cameras/{camera_id}/liveview"
     )
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 async def request_camera_sensors(blink, network, camera_id):
@@ -305,7 +319,9 @@ async def request_motion_detection_enable(blink, network, camera_id):
     :param camera_id: Camera ID of camera to enable.
     """
     url = f"{blink.urls.base_url}/network/{network}/camera/{camera_id}/enable"
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
@@ -317,7 +333,9 @@ async def request_motion_detection_disable(blink, network, camera_id):
     :param camera_id: Camera ID of camera to disable.
     """
     url = f"{blink.urls.base_url}/network/{network}/camera/{camera_id}/disable"
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 async def request_local_storage_manifest(blink, network, sync_id):
@@ -335,7 +353,9 @@ async def request_local_storage_manifest(blink, network, sync_id):
         f"/networks/{network}/sync_modules/{sync_id}"
         f"/local_storage/manifest/request"
     )
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 async def get_local_storage_manifest(blink, network, sync_id, manifest_request_id):
@@ -373,7 +393,9 @@ async def request_local_storage_clip(blink, network, sync_id, manifest_id, clip_
         manifest_id=manifest_id,
         clip_id=clip_id,
     )
-    return await http_post(blink, url)
+    response = await http_post(blink, url)
+    await wait_for_command(blink, response)
+    return response
 
 
 async def request_get_config(blink, network, camera_id, product_type="owl"):
@@ -467,3 +489,20 @@ async def http_post(blink, url, is_retry=False, data=None, json=True, timeout=TI
         json_resp=json,
         data=data,
     )
+
+
+async def wait_for_command(blink, json_data: dict) -> bool:
+    """Wait for command to complete."""
+    _LOGGER.debug("Command Wait %s", json_data)
+    network_id = json_data.get("network_id")
+    command_id = json_data.get("id")
+    if command_id and network_id:
+        while True:
+            _LOGGER.debug("Making GET request waiting for command")
+            status = await request_command_status(blink, network_id, command_id)
+            _LOGGER.debug("command status %s", status)
+            if status.get("complete"):
+                return True
+            if status.get("status_code", 0) != 908:
+                return False
+            await sleep(COMMAND_POLL_TIME)

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -471,7 +471,9 @@ class BlinkCameraMini(BlinkCamera):
             f"{self.network_id}/owls/{self.camera_id}/config"
         )
         data = dumps({"enabled": value})
-        return await api.http_post(self.sync.blink, url, json=False, data=data)
+        response = await api.http_post(self.sync.blink, url, data=data)
+        await api.wait_for_command(self.sync.blink, response)
+        return response
 
     async def snap_picture(self):
         """Snap picture for a blink mini camera."""
@@ -480,7 +482,9 @@ class BlinkCameraMini(BlinkCamera):
             f"{self.sync.blink.account_id}/networks/"
             f"{self.network_id}/owls/{self.camera_id}/thumbnail"
         )
-        return await api.http_post(self.sync.blink, url)
+        response = await api.http_post(self.sync.blink, url)
+        await api.wait_for_command(self.sync.blink, response)
+        return response
 
     async def get_sensor_info(self):
         """Get sensor info for blink mini camera."""
@@ -493,6 +497,7 @@ class BlinkCameraMini(BlinkCamera):
             f"{self.network_id}/owls/{self.camera_id}/liveview"
         )
         response = await api.http_post(self.sync.blink, url)
+        await api.wait_for_command(self.sync.blink, response)
         server = response["server"]
         server_split = server.split(":")
         server_split[0] = "rtsps:"
@@ -524,7 +529,10 @@ class BlinkDoorbell(BlinkCamera):
             url = f"{url}/enable"
         else:
             url = f"{url}/disable"
-        return await api.http_post(self.sync.blink, url)
+
+        response = await api.http_post(self.sync.blink, url)
+        await api.wait_for_command(self.sync.blink, response)
+        return response
 
     async def snap_picture(self):
         """Snap picture for a blink doorbell camera."""
@@ -533,7 +541,10 @@ class BlinkDoorbell(BlinkCamera):
             f"{self.sync.blink.account_id}/networks/"
             f"{self.sync.network_id}/doorbells/{self.camera_id}/thumbnail"
         )
-        return await api.http_post(self.sync.blink, url)
+
+        response = await api.http_post(self.sync.blink, url)
+        await api.wait_for_command(self.sync.blink, response)
+        return response
 
     async def get_sensor_info(self):
         """Get sensor info for blink doorbell camera."""
@@ -546,6 +557,7 @@ class BlinkDoorbell(BlinkCamera):
             f"{self.sync.network_id}/doorbells/{self.camera_id}/liveview"
         )
         response = await api.http_post(self.sync.blink, url)
+        await api.wait_for_command(self.sync.blink, response)
         server = response["server"]
         link = server.replace("immis://", "rtsps://")
         return link

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -679,17 +679,11 @@ class LocalStorageMediaItem:
 
     async def prepare_download(self, blink, max_retries=4):
         """Initiate upload of media item from the sync module to Blink cloud servers."""
+        if max_retries == 0:
+            return None
         url = blink.urls.base_url + self.url()
-        response = None
-        for retry in range(max_retries):
-            response = await api.http_post(blink, url)
-            if "id" in response:
-                break
-            seconds = backoff_seconds(retry=retry, default_time=3)
-            _LOGGER.debug(
-                "[retry=%d] Retrying in %d seconds: %s", retry + 1, seconds, url
-            )
-            await asyncio.sleep(seconds)
+        response = await api.http_post(blink, url)
+        await api.wait_for_command(blink, response)
         return response
 
     async def delete_video(self, blink, max_retries=4) -> bool:

--- a/tests/mock_responses.py
+++ b/tests/mock_responses.py
@@ -17,3 +17,7 @@ class MockResponse:
     async def json(self):
         """Return json data from get_request."""
         return self.json_data
+
+    def get(self, name):
+        """Return field for json."""
+        return self.json_data[name]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,7 @@ import tests.mock_responses as mresp
 
 COMMAND_RESPONSE = {"network_id": "12345", "id": "54321"}
 COMMAND_COMPLETE = {"complete": True, "status_code": 908}
+COMMAND_COMPLETE_BAD = {"complete": True, "status_code": 999}
 COMMAND_NOT_COMPLETE = {"complete": False, "status_code": 908}
 
 
@@ -176,5 +177,9 @@ class TestAPI(IsolatedAsyncioTestCase):
         assert response
 
         mock_resp.side_effect = (COMMAND_NOT_COMPLETE, {})
+        response = await api.wait_for_command(self.blink, COMMAND_RESPONSE)
+        self.assertFalse(response)
+
+        mock_resp.side_effect = (COMMAND_COMPLETE_BAD, {})
         response = await api.wait_for_command(self.blink, COMMAND_RESPONSE)
         self.assertFalse(response)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,10 @@ from blinkpy.blinkpy import Blink, util
 from blinkpy.auth import Auth
 import tests.mock_responses as mresp
 
+COMMAND_RESPONSE = {"network_id": "12345", "id": "54321"}
+COMMAND_COMPLETE = {"complete": True, "status_code": 908}
+COMMAND_NOT_COMPLETE = {"complete": False, "status_code": 908}
+
 
 @mock.patch("blinkpy.auth.Auth.query")
 class TestAPI(IsolatedAsyncioTestCase):
@@ -57,7 +61,7 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_command_status(self, mock_resp):
         """Test command_status."""
-        mock_resp.return_value = {"command": "done"}
+        mock_resp.side_effect = ({"command": "done"}, COMMAND_COMPLETE)
         self.assertEqual(
             await api.request_command_status(self.blink, "network", "command"),
             {"command": "done"},
@@ -65,13 +69,19 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_new_image(self, mock_resp):
         """Test api request new image."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_new_image(self.blink, "network", "camera")
         self.assertEqual(response.status, 200)
 
     async def test_request_new_video(self, mock_resp):
         """Test api request new Video."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_new_video(self.blink, "network", "camera")
         self.assertEqual(response.status, 200)
 
@@ -97,7 +107,10 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_motion_detection_enable(self, mock_resp):
         """Test  Motion detect enable."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_motion_detection_enable(
             self.blink, "network", "camera"
         )
@@ -105,7 +118,10 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_motion_detection_disable(self, mock_resp):
         """Test  Motion detect enable."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_motion_detection_disable(
             self.blink, "network", "camera"
         )
@@ -113,7 +129,10 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_local_storage_clip(self, mock_resp):
         """Test Motion detect enable."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.side_effect = (
+            mresp.MockResponse(COMMAND_RESPONSE, 200),
+            COMMAND_COMPLETE,
+        )
         response = await api.request_local_storage_clip(
             self.blink, "network", "sync_id", "manifest_id", "clip_id"
         )
@@ -135,7 +154,7 @@ class TestAPI(IsolatedAsyncioTestCase):
 
     async def test_request_update_config(self, mock_resp):
         """Test Motion detect enable."""
-        mock_resp.return_value = mresp.MockResponse({}, 200)
+        mock_resp.return_value = mresp.MockResponse(COMMAND_RESPONSE, 200)
         response = await api.request_update_config(
             self.blink, "network", "camera_id", "owl"
         )
@@ -149,3 +168,13 @@ class TestAPI(IsolatedAsyncioTestCase):
                 self.blink, "network", "camera_id", "other_camera"
             )
         )
+
+    async def test_wait_for_command(self, mock_resp):
+        """Test Motion detect enable."""
+        mock_resp.side_effect = (COMMAND_NOT_COMPLETE, COMMAND_COMPLETE)
+        response = await api.wait_for_command(self.blink, COMMAND_RESPONSE)
+        assert response
+
+        mock_resp.side_effect = (COMMAND_NOT_COMPLETE, {})
+        response = await api.wait_for_command(self.blink, COMMAND_RESPONSE)
+        self.assertFalse(response)

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -14,6 +14,7 @@ from blinkpy.sync_module import (
 from blinkpy.camera import BlinkCamera
 from tests.test_blink_functions import MockCamera
 import tests.mock_responses as mresp
+from .test_api import COMMAND_RESPONSE, COMMAND_COMPLETE
 
 
 @mock.patch("blinkpy.auth.Auth.query")
@@ -123,12 +124,12 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
 
     async def test_get_network_info_failure(self, mock_resp) -> None:
         """Test failed network retrieval."""
-        mock_resp.return_value = {}
+        mock_resp.side_effect = (COMMAND_RESPONSE, COMMAND_COMPLETE)
         self.blink.sync["test"].available = True
         self.assertFalse(await self.blink.sync["test"].get_network_info())
         self.assertFalse(self.blink.sync["test"].available)
         self.blink.sync["test"].available = True
-        mock_resp.return_value = None
+        mock_resp.side_effect = None
         self.assertFalse(await self.blink.sync["test"].get_network_info())
         self.assertFalse(self.blink.sync["test"].available)
 
@@ -238,7 +239,8 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         test_sync._local_storage["status"] = True
         test_sync.sync_id = 1234
         mock_resp.side_effect = [
-            {"id": 387372591, "network_id": 123456},
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
             {
                 "version": "1.0",
                 "manifest_id": "4321",
@@ -305,7 +307,8 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
             datetime.datetime.utcnow() - datetime.timedelta(seconds=60)
         ).isoformat()
         mock_resp.side_effect = [
-            {"id": 387372591, "network_id": 123456},
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
             {
                 "version": "1.0",
                 "manifest_id": "4321",
@@ -325,11 +328,15 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
                 ],
             },
             {"media": []},
-            {"id": 489371591, "network_id": 123456},
-            {"id": 489371592, "network_id": 123456},
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
             {"media": []},
-            {"id": 489371592, "network_id": 123456},
-            {"id": 489371592, "network_id": 123456},
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
         ]
 
         test_sync._names_table[to_alphanumeric("Front_Door")] = "Front_Door"
@@ -362,7 +369,7 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         test_sync.cameras["Back Door"] = MockCamera(self.blink.sync)
         test_sync.cameras["Front_Door"] = MockCamera(self.blink.sync)
         mock_poll.return_value = [
-            {"network_id": 123456},
+            {"network_id": "12345", "id": "54321"},
         ]
         test_sync._names_table[to_alphanumeric("Front_Door")] = "Front_Door"
         test_sync._names_table[to_alphanumeric("Back Door")] = "Back Door"
@@ -385,7 +392,8 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         ).isoformat()
 
         mock_resp.side_effect = [
-            {"id": 387372591, "network_id": 123456},
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
             {
                 "version": "1.0",
                 "clips": [
@@ -426,7 +434,8 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         ).isoformat()
 
         mock_resp.side_effect = [
-            {"id": 489371591, "network_id": 123456},
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
             {
                 "version": "1.0",
                 "manifest_id": "4321",
@@ -461,7 +470,8 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         test_sync.cameras["Front_Door"] = MockCamera(self.blink.sync)
 
         mock_resp.side_effect = [
-            {"network_id": 123456},
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
         ]
         test_sync._names_table[to_alphanumeric("Front_Door")] = "Front_Door"
         test_sync._names_table[to_alphanumeric("Back Door")] = "Back Door"
@@ -469,7 +479,7 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         response = await test_sync.poll_local_storage_manifest(max_retries=1)
         self.assertEqual(
             response,
-            {"network_id": 123456},
+            {"network_id": "12345", "id": "54321"},
         )
 
     async def test_sync_owl_init(self, mock_resp):
@@ -524,11 +534,13 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         self.assertFalse(item == item2)
 
         mock_resp.side_effect = [
-            {"network_id": 123456},
+            COMMAND_RESPONSE,
+            COMMAND_COMPLETE,
         ]
 
         self.assertEqual(
-            await item.prepare_download(blink, max_retries=1), {"network_id": 123456}
+            await item.prepare_download(blink, max_retries=1),
+            {"network_id": "12345", "id": "54321"},
         )
 
         with mock.patch("blinkpy.api.http_post", return_value=""):

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -369,7 +369,7 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         test_sync.cameras["Back Door"] = MockCamera(self.blink.sync)
         test_sync.cameras["Front_Door"] = MockCamera(self.blink.sync)
         mock_poll.return_value = [
-            {"network_id": "12345", "id": "54321"},
+            COMMAND_RESPONSE,
         ]
         test_sync._names_table[to_alphanumeric("Front_Door")] = "Front_Door"
         test_sync._names_table[to_alphanumeric("Back Door")] = "Back Door"
@@ -541,7 +541,7 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
 
         self.assertEqual(
             await item.prepare_download(blink, max_retries=1),
-            {"network_id": "12345", "id": "54321"},
+            COMMAND_RESPONSE,
         )
 
         with mock.patch("blinkpy.api.http_post", return_value=""):


### PR DESCRIPTION
## Description:
Fix the auth call to use existing session

**Related issue (if applicable):** fixes #759

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
