### PR TITLE
Fix blinkapp session call

### DIFF
--- a/blinkapp/blinkapp.py
+++ b/blinkapp/blinkapp.py
@@ -24,7 +24,7 @@ async def download_videos(blink, save_dir="/media"):
 async def start(session: ClientSession):
     """Startup blink app."""
     blink = Blink(session=session)
-    blink.auth = Auth(await json_load(CREDFILE))
+    blink.auth = Auth(await json_load(CREDFILE), session=session)
     await blink.start()
     return blink
 


### PR DESCRIPTION
## Description:
Fix the auth call to use existing session

**Related issue (if applicable):** fixes #759 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
