### PR TITLE
Speed up arm state determination

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -79,7 +79,6 @@ class Blink:
         self.homescreen = {}
         self.no_owls = no_owls
 
-    @util.Throttle(seconds=MIN_THROTTLE_TIME)
     async def refresh(self, force=False, force_cache=False):
         """
         Perform a system refresh.

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -114,7 +114,7 @@ class BlinkSyncModule:
             result = await api.request_system_disarm(self.blink, self.network_id)
         await self.get_network_info()
         return result
-    
+
     async def start(self):
         """Initialize the system."""
         _LOGGER.debug("Initializing the sync module")

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -109,7 +109,9 @@ class BlinkSyncModule:
     async def async_arm(self, value):
         """Arm or disarm camera."""
         if value:
+            self.network_info["network"]["armed"] = True
             return await api.request_system_arm(self.blink, self.network_id)
+        self.network_info["network"]["armed"] = False
         return await api.request_system_disarm(self.blink, self.network_id)
 
     async def start(self):

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -109,11 +109,12 @@ class BlinkSyncModule:
     async def async_arm(self, value):
         """Arm or disarm camera."""
         if value:
-            self.network_info["network"]["armed"] = True
-            return await api.request_system_arm(self.blink, self.network_id)
-        self.network_info["network"]["armed"] = False
-        return await api.request_system_disarm(self.blink, self.network_id)
-
+            result = await api.request_system_arm(self.blink, self.network_id)
+        else:
+            result = await api.request_system_disarm(self.blink, self.network_id)
+        await self.get_network_info()
+        return result
+    
     async def start(self):
         """Initialize the system."""
         _LOGGER.debug("Initializing the sync module")


### PR DESCRIPTION
## Description:

Set the state when arming/disarming the system until next update
I think we should wait a bit for a release to see if any other "bugs" show up since this one isn't a "show stopper".

**Related issue (if applicable):** fixes #https://github.com/home-assistant/core/issues/103536
## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
