### PR TITLE
fix arm status for mini cameras

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -476,7 +476,7 @@ class BlinkCameraMini(BlinkCamera):
     @property
     def arm(self):
         """Return camera arm status."""
-        return self.sync.arm
+        return self.motion_enabled
 
     async def async_arm(self, value):
         """Set camera arm status."""


### PR DESCRIPTION
- the arm status of mini cameras is now returned correctly
  - the status was mistakenly taken from the sync_module

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>
none

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [no] Tests added to verify new code works
