### PR TITLE
add missing entry in type_key_map

### DIFF
--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -51,6 +51,7 @@ class BlinkSyncModule:
         self.type_key_map = {
             "mini": "owls",
             "doorbell": "doorbells",
+            "outdoor": "cameras",
         }
         self._names_table = {}
         self._local_storage = {


### PR DESCRIPTION
## Description:

blinkpy/sync_module.py
- outdoor cameras - aka "default" have been missing in the type map
  - this meant that outdoor cameras could not be found via "get_unique_info"

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>
none

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [no] Tests added to verify new code works
