### PR TITLE
Allow kwargs to throttled functions, await sleep in throttle

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -131,7 +131,7 @@ async def request_syncmodule(blink, network):
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
-async def request_system_arm(blink, network):
+async def request_system_arm(blink, network, **kwargs):
     """
     Arm system.
 
@@ -148,7 +148,7 @@ async def request_system_arm(blink, network):
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
-async def request_system_disarm(blink, network):
+async def request_system_disarm(blink, network, **kwargs):
     """
     Disarm system.
 
@@ -177,14 +177,14 @@ async def request_command_status(blink, network, command_id):
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
-async def request_homescreen(blink):
+async def request_homescreen(blink, **kwargs):
     """Request homescreen info."""
     url = f"{blink.urls.base_url}/api/v3/accounts/{blink.account_id}/homescreen"
     return await http_get(blink, url)
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
-async def request_sync_events(blink, network):
+async def request_sync_events(blink, network, **kwargs):
     """
     Request events from sync module.
 
@@ -196,7 +196,7 @@ async def request_sync_events(blink, network):
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
-async def request_new_image(blink, network, camera_id):
+async def request_new_image(blink, network, camera_id, **kwargs):
     """
     Request to capture new thumbnail for camera.
 
@@ -211,7 +211,7 @@ async def request_new_image(blink, network, camera_id):
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
-async def request_new_video(blink, network, camera_id):
+async def request_new_video(blink, network, camera_id, **kwargs):
     """
     Request to capture new video clip.
 
@@ -226,7 +226,7 @@ async def request_new_video(blink, network, camera_id):
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
-async def request_video_count(blink):
+async def request_video_count(blink, **kwargs):
     """Request total video count."""
     url = f"{blink.urls.base_url}/api/v2/videos/count"
     return await http_get(blink, url)
@@ -311,7 +311,7 @@ async def request_camera_sensors(blink, network, camera_id):
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
-async def request_motion_detection_enable(blink, network, camera_id):
+async def request_motion_detection_enable(blink, network, camera_id, **kwargs):
     """
     Enable motion detection for a camera.
 
@@ -326,7 +326,7 @@ async def request_motion_detection_enable(blink, network, camera_id):
 
 
 @Throttle(seconds=MIN_THROTTLE_TIME)
-async def request_motion_detection_disable(blink, network, camera_id):
+async def request_motion_detection_disable(blink, network, camera_id, **kwargs):
     """
     Disable motion detection for a camera.
 

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -162,10 +162,6 @@ class Throttle:
     def __call__(self, method):
         """Throttle caller method."""
 
-        async def throttle_method():
-            """Call when method is throttled."""
-            return None
-
         @wraps(method)
         async def wrapper(*args, **kwargs):
             """Wrap that checks for throttling."""
@@ -179,4 +175,5 @@ class Throttle:
                 await sleep(last_call_delta)
 
             return await method(*args, **kwargs)
+
         return wrapper

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -168,7 +168,7 @@ class Throttle:
         @wraps(method)
         def wrapper(*args, **kwargs):
             """Wrap that checks for throttling."""
-            force = kwargs.pop("force", False)
+            force = kwargs.get("force", False)
             now = int(time.time())
             last_call_delta = now - self.last_call
             if force or last_call_delta > self.throttle_time:

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -173,7 +173,6 @@ class Throttle:
             now = int(time.time())
             last_call_delta = now - self.last_call
             if force or last_call_delta > self.throttle_time:
-                result = method(*args, **kwargs)
                 self.last_call = now
             else:
                 self.last_call = now + last_call_delta

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -7,6 +7,7 @@ import time
 import secrets
 import re
 import aiofiles
+from asyncio import sleep
 from calendar import timegm
 from functools import wraps
 from getpass import getpass
@@ -166,7 +167,7 @@ class Throttle:
             return None
 
         @wraps(method)
-        def wrapper(*args, **kwargs):
+        async def wrapper(*args, **kwargs):
             """Wrap that checks for throttling."""
             force = kwargs.get("force", False)
             now = int(time.time())
@@ -174,8 +175,9 @@ class Throttle:
             if force or last_call_delta > self.throttle_time:
                 result = method(*args, **kwargs)
                 self.last_call = now
-                return result
+            else:
+                self.last_call = now + last_call_delta
+                await sleep(last_call_delta)
 
-            return throttle_method()
-
+            return await method(*args, **kwargs)
         return wrapper

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -7,6 +7,7 @@ import time
 import secrets
 import re
 import aiofiles
+from asyncio import sleep
 from calendar import timegm
 from functools import wraps
 from getpass import getpass
@@ -161,21 +162,18 @@ class Throttle:
     def __call__(self, method):
         """Throttle caller method."""
 
-        async def throttle_method():
-            """Call when method is throttled."""
-            return None
-
         @wraps(method)
-        def wrapper(*args, **kwargs):
+        async def wrapper(*args, **kwargs):
             """Wrap that checks for throttling."""
-            force = kwargs.pop("force", False)
+            force = kwargs.get("force", False)
             now = int(time.time())
             last_call_delta = now - self.last_call
             if force or last_call_delta > self.throttle_time:
-                result = method(*args, **kwargs)
                 self.last_call = now
-                return result
+            else:
+                self.last_call = now + last_call_delta
+                await sleep(self.throttle_time - last_call_delta)
 
-            return throttle_method()
+            return await method(*args, **kwargs)
 
         return wrapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blinkpy"
-version = "0.23.0b1"
+version = "0.23.0b2"
 license = {text = "MIT"}
 description = "A Blink camera Python Library."
 readme = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blinkpy"
-version = "0.23.0b0"
+version = "0.23.0b1"
 license = {text = "MIT"}
 description = "A Blink camera Python Library."
 readme = "README.rst"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -39,31 +39,37 @@ class TestUtil(IsolatedAsyncioTestCase):
         now_plus_four = now + 4
         now_plus_six = now + 6
 
+        #First call should fire
         await test_throttle()
         self.assertEqual(1, len(calls))
 
-        # Call again, still shouldn't fire
+        # Call again, still should fire with delay
         await test_throttle()
-        self.assertEqual(1, len(calls))
+        self.assertEqual(2, len(calls))
+        assert int(time.time())-now >= 5
 
-        # Call with force
+        # Call with force 
         await test_throttle(force=True)
-        self.assertEqual(2, len(calls))
+        self.assertEqual(3, len(calls))
 
-        # Call without throttle, shouldn't fire
+        # Call without throttle, fire with delay
+        now = int(time.time())
         await test_throttle()
-        self.assertEqual(2, len(calls))
-
+        self.assertEqual(4, len(calls))
+        assert int(time.time())-now >= 5
+        
         # Fake time as 4 seconds from now
         with mock.patch("time.time", return_value=now_plus_four):
             await test_throttle()
-        self.assertEqual(2, len(calls))
-
+        self.assertEqual(5, len(calls))
+        assert int(time.time())-now >= 1
+        
         # Fake time as 6 seconds from now
         with mock.patch("time.time", return_value=now_plus_six):
             await test_throttle()
-        self.assertEqual(3, len(calls))
+        self.assertEqual(6, len(calls))
 
+        
     async def test_throttle_per_instance(self):
         """Test that throttle is done once per instance of class."""
 
@@ -76,8 +82,10 @@ class TestUtil(IsolatedAsyncioTestCase):
 
         tester = Tester()
         throttled = Throttle(seconds=1)(tester.test)
+        now = int(time.time())
         self.assertEqual(await throttled(), True)
-        self.assertEqual(await throttled(), None)
+        self.assertEqual(await throttled(), True)
+        assert int(time.time()) - now >= 1
 
     async def test_throttle_multiple_objects(self):
         """Test that function is throttled even if called by multiple objects."""
@@ -95,8 +103,10 @@ class TestUtil(IsolatedAsyncioTestCase):
 
         tester1 = Tester()
         tester2 = Tester()
+        now = int(time.time())
         self.assertEqual(await tester1.test(), True)
-        self.assertEqual(await tester2.test(), None)
+        self.assertEqual(await tester2.test(), True)
+        assert int(time.time()) - now >= 5
 
     async def test_throttle_on_two_methods(self):
         """Test that throttle works for multiple methods."""
@@ -115,23 +125,15 @@ class TestUtil(IsolatedAsyncioTestCase):
                 return True
 
         tester = Tester()
-        now = time.time()
-        now_plus_4 = now + 4
-        now_plus_6 = now + 6
+        now = int(time.time())
 
         self.assertEqual(await tester.test1(), True)
         self.assertEqual(await tester.test2(), True)
-        self.assertEqual(await tester.test1(), None)
-        self.assertEqual(await tester.test2(), None)
-
-        with mock.patch("time.time", return_value=now_plus_4):
-            self.assertEqual(await tester.test1(), True)
-            self.assertEqual(await tester.test2(), None)
-
-        with mock.patch("time.time", return_value=now_plus_6):
-            self.assertEqual(await tester.test1(), None)
-            self.assertEqual(await tester.test2(), True)
-
+        self.assertEqual(await tester.test1(), True)
+        assert int(time.time()) - now >= 3
+        self.assertEqual(await tester.test2(), True)
+        assert int(time.time()) - now >= 5
+        
     def test_time_to_seconds(self):
         """Test time to seconds conversion."""
         correct_time = "1970-01-01T00:00:05+00:00"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -36,8 +36,6 @@ class TestUtil(IsolatedAsyncioTestCase):
             calls.append(1)
 
         now = int(time.time())
-        now_plus_four = now + 4
-        now_plus_six = now + 6
 
         # First call should fire
         await test_throttle()
@@ -54,20 +52,10 @@ class TestUtil(IsolatedAsyncioTestCase):
 
         # Call without throttle, fire with delay
         now = int(time.time())
+
         await test_throttle()
         self.assertEqual(4, len(calls))
         assert int(time.time()) - now >= 5
-
-        # Fake time as 4 seconds from now
-        with mock.patch("time.time", return_value=now_plus_four):
-            await test_throttle()
-        self.assertEqual(5, len(calls))
-        assert int(time.time()) - now >= 1
-
-        # Fake time as 6 seconds from now
-        with mock.patch("time.time", return_value=now_plus_six):
-            await test_throttle()
-        self.assertEqual(6, len(calls))
 
     async def test_throttle_per_instance(self):
         """Test that throttle is done once per instance of class."""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -39,16 +39,16 @@ class TestUtil(IsolatedAsyncioTestCase):
         now_plus_four = now + 4
         now_plus_six = now + 6
 
-        #First call should fire
+        # First call should fire
         await test_throttle()
         self.assertEqual(1, len(calls))
 
         # Call again, still should fire with delay
         await test_throttle()
         self.assertEqual(2, len(calls))
-        assert int(time.time())-now >= 5
+        assert int(time.time()) - now >= 5
 
-        # Call with force 
+        # Call with force
         await test_throttle(force=True)
         self.assertEqual(3, len(calls))
 
@@ -56,20 +56,19 @@ class TestUtil(IsolatedAsyncioTestCase):
         now = int(time.time())
         await test_throttle()
         self.assertEqual(4, len(calls))
-        assert int(time.time())-now >= 5
-        
+        assert int(time.time()) - now >= 5
+
         # Fake time as 4 seconds from now
         with mock.patch("time.time", return_value=now_plus_four):
             await test_throttle()
         self.assertEqual(5, len(calls))
-        assert int(time.time())-now >= 1
-        
+        assert int(time.time()) - now >= 1
+
         # Fake time as 6 seconds from now
         with mock.patch("time.time", return_value=now_plus_six):
             await test_throttle()
         self.assertEqual(6, len(calls))
 
-        
     async def test_throttle_per_instance(self):
         """Test that throttle is done once per instance of class."""
 
@@ -133,7 +132,7 @@ class TestUtil(IsolatedAsyncioTestCase):
         assert int(time.time()) - now >= 3
         self.assertEqual(await tester.test2(), True)
         assert int(time.time()) - now >= 5
-        
+
     def test_time_to_seconds(self):
         """Test time to seconds conversion."""
         correct_time = "1970-01-01T00:00:05+00:00"

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
     LANG=en_US.UTF-8
     PYTHONPATH = {toxinidir}
 commands =
-    pytest --timeout=9 --durations=10 --cov=blinkpy --cov-report term-missing {posargs}
+    pytest --timeout=15 --durations=10 --cov=blinkpy --cov-report term-missing {posargs}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_test.txt
@@ -19,7 +19,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 commands =
     pip install -e .
-    pytest --timeout=9 --durations=10 --cov=blinkpy --cov-report=xml {posargs}
+    pytest --timeout=15 --durations=10 --cov=blinkpy --cov-report=xml {posargs}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
     LANG=en_US.UTF-8
     PYTHONPATH = {toxinidir}
 commands =
-    pytest --timeout=15 --durations=10 --cov=blinkpy --cov-report term-missing {posargs}
+    pytest --timeout=30 --durations=10 --cov=blinkpy --cov-report term-missing {posargs}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_test.txt
@@ -19,7 +19,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 commands =
     pip install -e .
-    pytest --timeout=15 --durations=10 --cov=blinkpy --cov-report=xml {posargs}
+    pytest --timeout=30 --durations=10 --cov=blinkpy --cov-report=xml {posargs}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements_test.txt


### PR DESCRIPTION
## Description:
Move back to .get() for throttle kwargs
Add time delay to actually "throttle" the call rather than "ignore" the call.

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
