### PR TITLE
correct typos and enforce one sentence per line in documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -58,7 +58,7 @@ Probably not strictly needed but checking result can verify that the sync module
 
 
 ## Arm
- 
+
 Arm the given network (start recording/reporting motion events)
 
 **Request:**
@@ -116,12 +116,12 @@ Not necessary to as part of issuing arm/disarm commands, but contains good summa
 ## Events, thumbnails & video captures
 
 **Request**
-Get events for a given network (sync module) -- Need network ID from home 
+Get events for a given network (sync module) -- Need network ID from home
 
 >curl -H "Host: prod.immedia-semi.com" -H "TOKEN_AUTH: *authtoken from login*" --compressed https://rest.prod.immedia-semi.com/events/network/*network__id*
 
 **Response**
-A json list of evets incluing URL's.   Replace the "mp4" with "jpg" extension to get the thumbnail of each clip
+A json list of events including URL's.   Replace the "mp4" with "jpg" extension to get the thumbnail of each clip
 
 
 **Request**
@@ -138,7 +138,7 @@ Get a thumbnail from the events list
 >curl -H "Host: prod.immedia-semi.com" -H "TOKEN_AUTH: *authtoken from login*" --compressed **video url from events list.jpg** > video_thumb.jpg
 
 **Response**
-The jpg bytes. 
+The jpg bytes.
 
 **Notes**
 Note that you replace the 'mp4' with a 'jpg' to get the thumbnail
@@ -149,7 +149,7 @@ Captures a new thumbnail for a camera
 >curl -H "Host: prod.immedia-semi.com" -H "TOKEN_AUTH: *authtoken from login*" --data-binary --compressed https://rest.prod.immedia-semi.com/network/*network_id*/camera/*camera_id*/thumbnail
 
 **Response**
-Command information. 
+Command information.
 
 **Request**
 Captures a new video for a camera

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ Same as 0.22.1 (pypi upload issue)
 **Other Changes**
 
 - Cleanup readme, add breaking change warning
-- Migrate to puproject.toml + ruff
+- Migrate to pyproject.toml + ruff
 - Bump ruff to 0.0.292
 - Bump black to 23.9.1
 - Bump coverage to 7.3.2
@@ -287,12 +287,12 @@ Same as 0.22.1 (pypi upload issue)
 **New Features:**
 
 - Add is_errored property to Auth class (`@fronzbot #275 <https://github.com/fronzbot/blinkpy/pull/275>`__)
-- Add new endpoint to get user infor (`@fronzbot #280 <https://github.com/fronzbot/blinkpy/pull/280>`__)
+- Add new endpoint to get user info (`@fronzbot #280 <https://github.com/fronzbot/blinkpy/pull/280>`__)
 - Add get_liveview command to camera module (`@fronzbot #289 <https://github.com/fronzbot/blinkpy/pull/289>`__)
 - Add blink Mini Camera support (`@fronzbot #290 <https://github.com/fronzbot/blinkpy/pull/290>`__)
 - Add option to skip homescreen check (`@fronzbot #305 <https://github.com/fronzbot/blinkpy/pull/305>`__)
 - Add different timeout for video and image retrieval (`@fronzbot #323 <https://github.com/fronzbot/blinkpy/pull/323>`__)
-- Modifiy session to use HTTPAdapter and handle retries (`@fronzbot #324 <https://github.com/fronzbot/blinkpy/pull/324>`__)
+- Modify session to use HTTPAdapter and handle retries (`@fronzbot #324 <https://github.com/fronzbot/blinkpy/pull/324>`__)
 - Add retry option overrides (`@fronzbot #339 <https://github.com/fronzbot/blinkpy/pull/339>`__)
 
 **All changes:**
@@ -316,7 +316,7 @@ Please see the change list in the (`Release Notes <https://github.com/fronzbot/r
 
 - Add ``device_id`` override when logging in (for debug and to differentiate applications) (`@fronzbot #245 <https://github.com/fronzbot/blinkpy/pull/245>`__)
 
-This can be used by instantiating the Blink class with the ``device_id`` parameter. 
+This can be used by instantiating the Blink class with the ``device_id`` parameter.
 
 **All Changes:**
 
@@ -326,7 +326,7 @@ This can be used by instantiating the Blink class with the ``device_id`` paramet
 - Bump requests from 2.22.0 to 2.23.0 (`@fronzbot #231 <https://github.com/fronzbot/blinkpy/pull/231>`__)
 - Refactor login logic in preparation for 2FA (`@fronzbot #241 <https://github.com/fronzbot/blinkpy/pull/241>`__)
 - Add 2FA Support (`@fronzbot #242 <https://github.com/fronzbot/blinkpy/pull/242>`__) (fixes (`#210 <https://github.com/fronzbot/blinkpy/pull/210>`__))
-- Re-set key_required and available variables after setup (`@fronzbot #245 <https://github.com/fronzbot/blinkpy/pull/245>`__) 
+- Re-set key_required and available variables after setup (`@fronzbot #245 <https://github.com/fronzbot/blinkpy/pull/245>`__)
 - Perform system refresh after setup (`@fronzbot #245 <https://github.com/fronzbot/blinkpy/pull/245>`__)
 - Fix typos (`@fronzbot #244 <https://github.com/fronzbot/blinkpy/pull/244>`__)
 
@@ -429,7 +429,7 @@ Wifi status reported in dBm again, instead of bars (which is great).  Also, the 
 
 0.10.3 (2018-11-18)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- Use networks endpoint rather than homecreen to retrieve arm/disarm status (`@md-reddevil <https://github.com/fronzbot/blinkpy/pull/119>`__)
+- Use networks endpoint rather than homescreen to retrieve arm/disarm status (`@md-reddevil <https://github.com/fronzbot/blinkpy/pull/119>`__)
 - Fix incorrect command status endpoint (`@md-reddevil <https://github.com/fronzbot/blinkpy/pull/118>`__)
 - Add extra debug logging
 - Remove error prior to re-authorization (only log error when re-auth failed)
@@ -438,7 +438,7 @@ Wifi status reported in dBm again, instead of bars (which is great).  Also, the 
 0.10.2 (2018-10-30)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - Set minimum required version of the requests library to 2.20.0 due to vulnerability in earlier releases.
-- When multiple networks detected, changed log level to ``warning`` from ``error`` 
+- When multiple networks detected, changed log level to ``warning`` from ``error``
 
 
 0.10.1 (2018-10-18)
@@ -450,7 +450,7 @@ Wifi status reported in dBm again, instead of bars (which is great).  Also, the 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - Moved all API calls to own module for easier maintainability
 - Added network ids to sync module and cameras to allow for multi-network use
-- Removed dependency on video existance prior to camera setup (fixes `#93 <https://github.com/fronzbot/blinkpy/issues/#93>`__)
+- Removed dependency on video existence prior to camera setup (fixes `#93 <https://github.com/fronzbot/blinkpy/issues/#93>`__)
 - Camera wifi_strength now reported in wifi "bars" rather than dBm due to API endpoint change
 - Use homescreen thumbnail as fallback in case it's not in the camera endpoint
 - Removed "armed" and "status" attributes from camera (status of camera only reported by "motion_enabled" now)
@@ -490,7 +490,7 @@ Wifi status reported in dBm again, instead of bars (which is great).  Also, the 
 - Added support for battery voltage level (fixes `#64 <https://github.com/fronzbot/blinkpy/issues/64>`__)
 - Added motion detection per camera
 - Added fully accessible camera configuration dict
-- Added celcius property to camera (fixes `#60 <https://github.com/fronzbot/blinkpy/issues/60>`__)
+- Added celsius property to camera (fixes `#60 <https://github.com/fronzbot/blinkpy/issues/60>`__)
 
 0.7.1 (2018-05-09)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -512,7 +512,7 @@ Wifi status reported in dBm again, instead of bars (which is great).  Also, the 
 
 0.6.0 (2017-05-12)
 ~~~~~~~~~~~~~~~~~~
-- Removed redundent properties that only called hidden variables
+- Removed redundant properties that only called hidden variables
 - Revised request wrapper function to be more intelligent
 - Added tests to ensure exceptions are caught and handled (100% coverage!)
 - Added auto-reauthorization (token refresh) when a request fails due to an expired token (`@tySwift93 <https://github.com/fronzbot/blinkpy/pull/24>`__)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -16,7 +16,7 @@ Start Developing
 1. Setup Local Repository
 
    .. code:: bash
-       
+
        $ git clone https://github.com/<YOUR_GIT_USERNAME>/blinkpy.git
        $ cd blinkpy
        $ git remote add upstream https://github.com/fronzbot/blinkpy.git
@@ -32,27 +32,27 @@ Start Developing
        $ pre-commit install
 
 3. Create a Local Branch
-   
+
    First, you will want to create a new branch to hold your changes:
    ``git checkout -b <your-branch-name>``
 
 
 4. Make changes
-   
+
    Now you can make changes to your code.  It is worthwhile to test your code as you progress (see the **Testing** section)
 
 5. Commit Your Changes
-   
+
    To commit changes to your branch, simply add the files you want and the commit them to the branch.  After that, you can push to your fork on GitHub:
 
    .. code:: bash
-   
+
        $ git add .
        $ git commit
        $ git push origin HEAD
-   
+
 6. Submit your pull request on GitHub
-   
+
    - On GitHub, navigate to the `blinkpy <https://github.com/fronzbot/blinkpy>`__ repository.
    - In the "Branch" menu, choose the branch that contains your commits (from your fork).
    - To the right of the Branch menu, click New pull request.
@@ -60,9 +60,9 @@ Start Developing
    - Type a title and complete the provided description for your pull request.
    - Click Create pull request.
    - More detailed instructions can be found here: `Creating a Pull Request` <https://help.github.com/articles/creating-a-pull-request>`__
-   
+
 7. Prior to merge approval
-   
+
    Finally, the ``blinkpy`` repository uses continuous integration tools to run tests prior to merging. If there are any problems, you  will see a red 'X' next to your pull request.
 
 
@@ -80,14 +80,14 @@ First, you need to locally install ``tox``
 You can then run all of the tests with the following command:
 
 .. code:: bash
-    
+
     $ tox
 
 **Tips**
 
 If you only want to see if you can pass the local tests, you can run ``tox -e py37`` (or whatever python version you have installed.  Only ``py36``, ``py37``, and ``py38`` will be accepted).  If you just want to check for style violations, you can run ``tox -e lint``.  Regardless, when you submit a pull request, your code MUST pass both the unit tests, and the linters.
 
-If you need to change anything in ``requirements.txt`` for any reason, you'll want to regenerate the virtual envrionments used by ``tox`` by running with the ``-r`` flag: ``tox -r``
+If you need to change anything in ``requirements.txt`` for any reason, you'll want to regenerate the virtual environments used by ``tox`` by running with the ``-r`` flag: ``tox -r``
 
 If you want to run a single test (perhaps you only changed a small thing in one file) you can run ``tox -e py37 -- tests/<testname>.py -x``.  This will run the test ``<testname>.py`` and stop testing upon the first failure, making it easier to figure out why a particular test might be failing.  The test structure mimics the library structure, so if you changed something in ``sync_module.py``, the associated test file would be in ``test_sync_module.py`` (ie. the filename is prepended with ``test_``.
 
@@ -104,7 +104,7 @@ If your code is taking a while to develop, you may be behind the ``dev`` branch,
 
 If rebase detects conflicts, repeat the following process until all changes have been resolved:
 
-1. ``git status`` shows you the filw with a conflict.  You will need to edit that file and resolve the lines between ``<<<< | >>>>``.
+1. ``git status`` shows you the file(s) with a conflict.  You will need to edit that file and resolve the lines between ``<<<< | >>>>``.
 2. Add the modified file: ``git add <file>`` or ``git add .``.
 3. Continue rebase: ``git rebase --continue``.
 4. Repeat until all conflicts resolved.

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,8 @@ Like the library? Consider buying me a cup of coffee!
 `Buy me a Coffee! <https://buymeacoffee.com/kevinfronczak>`__
 
 **BREAKING CHANGE WARNING:**
-As of ``0.22.0`` the library uses asyncio which will break any user scripts used prior to this version. Please see the updated examples below and the ``blinkapp.py`` or ``blinksync.py`` examples in the ``blinkapp/`` directory for examples on how to migrate.
+As of ``0.22.0`` the library uses asyncio which will break any user scripts used prior to this version.
+Please see the updated examples below and the ``blinkapp.py`` or ``blinksync.py`` examples in the ``blinkapp/`` directory for examples on how to migrate.
 
 **Disclaimer:**
 Published under the MIT license - See LICENSE file for more details.
@@ -17,7 +18,8 @@ I am in no way affiliated with Blink, nor Immedia Inc.
 
 Original protocol hacking by MattTW : https://github.com/MattTW/BlinkMonitorProtocol
 
-API calls faster than 60 seconds is not recommended as it can overwhelm Blink's servers.  Please use this module responsibly.
+API calls faster than 60 seconds is not recommended as it can overwhelm Blink's servers.
+Please use this module responsibly.
 
 Installation
 -------------
@@ -25,7 +27,8 @@ Installation
 
 Installing Development Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-To install the current development version, perform the following steps.  Note that the following will create a blinkpy directory in your home area:
+To install the current development version, perform the following steps.
+Note that the following will create a blinkpy directory in your home area:
 
 .. code:: bash
 
@@ -46,27 +49,33 @@ This library was built with the intention of allowing easy communication with Bl
 
 Quick Start
 =============
-The simplest way to use this package from a terminal is to call ``await Blink.start()`` which will prompt for your Blink username and password and then log you in.  In addition, http requests are throttled internally via use of the ``Blink.refresh_rate`` variable, which can be set at initialization and defaults to 30 seconds.
+The simplest way to use this package from a terminal is to call ``await Blink.start()`` which will prompt for your Blink username and password and then log you in.
+In addition, http requests are throttled internally via use of the ``Blink.refresh_rate`` variable, which can be set at initialization and defaults to 30 seconds.
 
 .. code:: python
-    
+
     import asyncio
     from aiohttp import ClientSession
     from blinkpy.blinkpy import Blink
-   
+
     async def start():
         blink = Blink(session=ClientSession())
         await blink.start()
         return blink
 
-    blink = asyncio.run(start()) 
+    blink = asyncio.run(start())
 
 
-This flow will prompt you for your username and password.  Once entered, if you likely will need to send a 2FA key to the blink servers (this pin is sent to your email address).  When you receive this pin, enter at the prompt and the Blink library will proceed with setup.
+This flow will prompt you for your username and password.
+Once entered, if you likely will need to send a 2FA key to the blink servers (this pin is sent to your email address).
+When you receive this pin, enter at the prompt and the Blink library will proceed with setup.
 
 Starting blink without a prompt
 -------------------------------
-In some cases, having an interactive command-line session is not desired.  In this case, you will need to set the ``Blink.auth.no_prompt`` value to ``True``.  In addition, since you will not be prompted with a username and password, you must supply the login data to the blink authentication handler.  This is best done by instantiating your own auth handler with a dictionary containing at least your username and password.
+In some cases, having an interactive command-line session is not desired.
+In this case, you will need to set the ``Blink.auth.no_prompt`` value to ``True``.
+In addition, since you will not be prompted with a username and password, you must supply the login data to the blink authentication handler.
+This is best done by instantiating your own auth handler with a dictionary containing at least your username and password.
 
 .. code:: python
 
@@ -86,7 +95,8 @@ In some cases, having an interactive command-line session is not desired.  In th
     blink = asyncio.run(start())
 
 
-Since you will not be prompted for any 2FA pin, you must call the ``blink.auth.send_auth_key`` function.  There are two required parameters: the ``blink`` object as well as the ``key`` you received from Blink for 2FA:
+Since you will not be prompted for any 2FA pin, you must call the ``blink.auth.send_auth_key`` function.
+There are two required parameters: the ``blink`` object as well as the ``key`` you received from Blink for 2FA:
 
 .. code:: python
 
@@ -96,7 +106,10 @@ Since you will not be prompted for any 2FA pin, you must call the ``blink.auth.s
 
 Supplying credentials from file
 --------------------------------
-Other use cases may involved loading credentials from a file.  This file must be ``json`` formatted and contain a minimum of ``username`` and ``password``.  A built in function in the ``blinkpy.helpers.util`` module can aid in loading this file.  Note, if ``no_prompt`` is desired, a similar flow can be followed as above.
+Other use cases may involved loading credentials from a file.
+This file must be ``json`` formatted and contain a minimum of ``username`` and ``password``.
+A built in function in the ``blinkpy.helpers.util`` module can aid in loading this file.
+Note, if ``no_prompt`` is desired, a similar flow can be followed as above.
 
 .. code:: python
 
@@ -118,7 +131,9 @@ Other use cases may involved loading credentials from a file.  This file must be
 
 Saving credentials
 -------------------
-This library also allows you to save your credentials to use in future sessions.  Saved information includes authentication tokens as well as unique ids which should allow for a more streamlined experience and limits the frequency of login requests.  This data can be saved as follows (it can then be loaded by following the instructions above for supplying credentials from a file):
+This library also allows you to save your credentials to use in future sessions.
+Saved information includes authentication tokens as well as unique ids which should allow for a more streamlined experience and limits the frequency of login requests.
+This data can be saved as follows (it can then be loaded by following the instructions above for supplying credentials from a file):
 
 .. code:: python
 
@@ -127,7 +142,8 @@ This library also allows you to save your credentials to use in future sessions.
 
 Getting cameras
 ----------------
-Cameras are instantiated as individual ``BlinkCamera`` classes within a ``BlinkSyncModule`` instance.  All of your sync modules are stored within the ``Blink.sync`` dictionary and can be accessed using the name of the sync module as the key (this is the name of your sync module in the Blink App).
+Cameras are instantiated as individual ``BlinkCamera`` classes within a ``BlinkSyncModule`` instance.
+All of your sync modules are stored within the ``Blink.sync`` dictionary and can be accessed using the name of the sync module as the key (this is the name of your sync module in the Blink App).
 
 The below code will display cameras and their available attributes:
 
@@ -138,10 +154,12 @@ The below code will display cameras and their available attributes:
       print(camera.attributes)      # Print available attributes of camera
 
 
-The most recent images and videos can be accessed as a bytes-object via internal variables.  These can be updated with calls to ``Blink.refresh()`` but will only make a request if motion has been detected or other changes have been found.  This can be overridden with the ``force`` flag, but this should be used for debugging only since it overrides the internal request throttling.
+The most recent images and videos can be accessed as a bytes-object via internal variables.
+These can be updated with calls to ``Blink.refresh()`` but will only make a request if motion has been detected or other changes have been found.
+This can be overridden with the ``force`` flag, but this should be used for debugging only since it overrides the internal request throttling.
 
 .. code:: python
-    
+
     camera = blink.cameras['SOME CAMERA NAME']
     await blink.refresh(force=True)  # force a cache update USE WITH CAUTION
     camera.image_from_cache  # bytes-like image object (jpg)
@@ -160,7 +178,8 @@ The ``blinkpy`` api also allows for saving images and videos to a file and snapp
 
 Arming Blink
 -------------
-Methods exist to arm/disarm the sync module, as well as enable/disable motion detection for individual cameras.  This is done as follows:
+Methods exist to arm/disarm the sync module, as well as enable/disable motion detection for individual cameras.
+This is done as follows:
 
 .. code:: python
 
@@ -194,7 +213,15 @@ Similar methods exist for individual cameras:
 
 Download videos
 ----------------
-You can also use this library to download all videos from the server.  In order to do this, you must specify a ``path``.  You may also specifiy a how far back in time to go to retrieve videos via the ``since=`` variable (a simple string such as ``"2017/09/21"`` is sufficient), as well as how many pages to traverse via the ``stop=`` variable.  Note that by default, the library will search the first ten pages which is sufficient in most use cases.  Additionally, you can specify one or more cameras via the ``camera=`` property.  This can be a single string indicating the name of the camera, or a list of camera names.  By default, it is set to the string ``'all'`` to grab videos from all cameras. If you are downloading many items, setting the ``delay`` parameter is advised in order to throttle sequential calls to the API. By default this is set to ``1`` but can be any integer representing the number of seconds to delay between calls.
+You can also use this library to download all videos from the server.
+In order to do this, you must specify a ``path``.
+You may also specify a how far back in time to go to retrieve videos via the ``since=`` variable (a simple string such as ``"2017/09/21"`` is sufficient), as well as how many pages to traverse via the ``stop=`` variable.
+Note that by default, the library will search the first ten pages which is sufficient in most use cases.
+Additionally, you can specify one or more cameras via the ``camera=`` property.
+This can be a single string indicating the name of the camera, or a list of camera names.
+By default, it is set to the string ``'all'`` to grab videos from all cameras.
+If you are downloading many items, setting the ``delay`` parameter is advised in order to throttle sequential calls to the API.
+By default this is set to ``1`` but can be any integer representing the number of seconds to delay between calls.
 
 Example usage, which downloads all videos recorded since July 4th, 2018 at 9:34am to the ``/home/blink`` directory with a 2s delay between calls:
 
@@ -209,14 +236,14 @@ Sync Module Local Storage
 Description of how I think the local storage API is used by Blink
 -----------------------------------------------------------------
 
-Since local storage is within a customer's residence, there are no guarantees for latency
-and availability.  As a result, the API seems to be built to deal with these conditions.
+Since local storage is within a customer's residence, there are no guarantees for latency and availability.
+As a result, the API seems to be built to deal with these conditions.
 
-In general, the approach appears to be this:  The Blink app has to query the sync
-module for all information regarding the stored clips.  On a click to view a clip, the app asks
-for the full list of stored clips, finds the clip in question, uploads the clip to the
-cloud, and then downloads the clip back from a cloud URL. Each interaction requires polling for
-the response since networking conditions are uncertain.  The app also caches recent clips and the manifest.
+In general, the approach appears to be this:
+The Blink app has to query the sync module for all information regarding the stored clips.
+On a click to view a clip, the app asks for the full list of stored clips, finds the clip in question, uploads the clip to the cloud, and then downloads the clip back from a cloud URL.
+Each interaction requires polling for the response since networking conditions are uncertain.
+The app also caches recent clips and the manifest.
 
 API steps
 ---------

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -192,7 +192,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         self.assertEqual(self.camera.recent_clips[1], record2)
 
     async def test_recent_video_clips_missing_key(self, mock_resp):
-        """Tests that the missing key failst."""
+        """Tests that the missing key fails."""
         config = {
             "name": "new",
             "id": 1234,
@@ -337,7 +337,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     @mock.patch("blinkpy.camera.open", create=True)
     async def test_video_to_file(self, mock_open, mock_resp):
-        """Test camera vido to file with error."""
+        """Test camera video to file with error."""
         mock_resp.return_value = mresp.MockResponse({}, 400, raw_data="raw data")
         self.camera.clip = "my_clip"
         await self.camera.video_to_file("my_path")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -11,7 +11,7 @@ from blinkpy.helpers.errors import (
 
 
 class TestBlinkUtilsErrors(unittest.TestCase):
-    """Test BlinkUtilErros functions in blinkpy."""
+    """Test BlinkUtilErrors functions in blinkpy."""
 
     def test_helpers_errors(self) -> None:
         """Test the helper errors."""


### PR DESCRIPTION
## Description:
- correct some typos
  - in code
  - in documentation
- change rst files to "one sentence per line" recommendation

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [n] Changes tested locally to ensure platform still works as intended
- [n] Tests added to verify new code works
