### PR TITLE
Add new keys for wifi, lfr, and battery

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -233,22 +233,12 @@ class BlinkCamera:
         self.network_id = str(config.get("network_id", "unknown"))
         self.serial = config.get("serial")
         self.motion_enabled = config.get("enabled", "unknown")
-        self.battery_voltage = config.get("battery_voltage")
         self.battery_state = config.get("battery_state") or config.get("battery")
         self.temperature = config.get("temperature")
         if signals := config.get("signals"):
-            try:  # x / 5 * 100 = x * 20 for percentage
-                self.wifi_strength = signals.get("wifi") * 20
-            except TypeError:
-                self.wifi_strength = None
-            try:
-                self.battery_voltage = signals.get("battery") * 20
-            except TypeError:
-                self.battery_voltage = None
-            try:
-                self.sync_signal = signals.get("lfr") * 20
-            except TypeError:
-                self.sync_signal = None
+            self.wifi_strength = signals.get("wifi")
+            self.battery_voltage = signals.get("battery")
+            self.sync_signal = signals.get("lfr")
         else:
             self.wifi_strength = config.get("wifi_strength")
             self.battery_voltage = config.get("battery_voltage")

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -43,7 +43,7 @@ class BlinkCamera:
         self._cached_video = None
         self.camera_type = ""
         self.product_type = None
-        self.sync_signal = None
+        self.sync_signal_strength = None
 
     @property
     def attributes(self):
@@ -56,7 +56,7 @@ class BlinkCamera:
             "temperature_c": self.temperature_c,
             "temperature_calibrated": self.temperature_calibrated,
             "battery": self.battery,
-            "battery_voltage": self.battery_voltage,
+            "battery_level": self.battery_level,
             "thumbnail": self.thumbnail,
             "video": self.clip,
             "recent_clips": self.recent_clips,

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -65,7 +65,7 @@ class BlinkCamera:
             "wifi_strength": self.wifi_strength,
             "network_id": self.sync.network_id,
             "sync_module": self.sync.name,
-            "sync_signal": self.sync_signal,
+            "sync_signal_strength": self.sync_signal_strength,
             "last_record": self.last_record,
             "type": self.product_type,
         }
@@ -238,7 +238,7 @@ class BlinkCamera:
         if signals := config.get("signals"):
             self.wifi_strength = signals.get("wifi")
             self.battery_voltage = signals.get("battery")
-            self.sync_signal = signals.get("lfr")
+            self.sync_signal_strength = signals.get("lfr")
         else:
             self.wifi_strength = config.get("wifi_strength")
             self.battery_voltage = config.get("battery_voltage")

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -237,9 +237,18 @@ class BlinkCamera:
         self.battery_state = config.get("battery_state") or config.get("battery")
         self.temperature = config.get("temperature")
         if signals := config.get("signals"):
-            self.wifi_strength = signals.get("wifi")
-            self.battery_voltage = signals.get("battery")
-            self.sync_signal = signals.get("lfr")
+            try:  # x / 5 * 100 = x * 20 for percentage
+                self.wifi_strength = signals.get("wifi") * 20
+            except TypeError:
+                self.wifi_strength = None
+            try:
+                self.battery_voltage = signals.get("battery") * 20
+            except TypeError:
+                self.battery_voltage = None
+            try:
+                self.sync_signal = signals.get("lfr") * 20
+            except TypeError:
+                self.sync_signal = None
         else:
             self.wifi_strength = config.get("wifi_strength")
             self.battery_voltage = config.get("battery_voltage")

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -56,7 +56,7 @@ class BlinkCamera:
             "temperature_c": self.temperature_c,
             "temperature_calibrated": self.temperature_calibrated,
             "battery": self.battery,
-            "battery_level": self.battery_voltage,
+            "battery_voltage": self.battery_voltage,
             "thumbnail": self.thumbnail,
             "video": self.clip,
             "recent_clips": self.recent_clips,

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -56,7 +56,7 @@ class BlinkCamera:
             "temperature_c": self.temperature_c,
             "temperature_calibrated": self.temperature_calibrated,
             "battery": self.battery,
-            "battery_level": self.battery_level,
+            "battery_level": self.battery_voltage,
             "thumbnail": self.thumbnail,
             "video": self.clip,
             "recent_clips": self.recent_clips,

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -43,6 +43,7 @@ class BlinkCamera:
         self._cached_video = None
         self.camera_type = ""
         self.product_type = None
+        self.sync_signal = None
 
     @property
     def attributes(self):
@@ -64,6 +65,7 @@ class BlinkCamera:
             "wifi_strength": self.wifi_strength,
             "network_id": self.sync.network_id,
             "sync_module": self.sync.name,
+            "sync_signal": self.sync_signal,
             "last_record": self.last_record,
             "type": self.product_type,
         }
@@ -229,15 +231,20 @@ class BlinkCamera:
         self.name = config.get("name", "unknown")
         self.camera_id = str(config.get("id", "unknown"))
         self.network_id = str(config.get("network_id", "unknown"))
-        self.serial = config.get("serial", None)
+        self.serial = config.get("serial")
         self.motion_enabled = config.get("enabled", "unknown")
-        self.battery_voltage = config.get("battery_voltage", None)
-        self.battery_state = config.get("battery_state", None) or config.get(
-            "battery", None
-        )
-        self.temperature = config.get("temperature", None)
-        self.wifi_strength = config.get("wifi_strength", None)
-        self.product_type = config.get("type", None)
+        self.battery_voltage = config.get("battery_voltage")
+        self.battery_state = config.get("battery_state") or config.get("battery")
+        self.temperature = config.get("temperature")
+        if signals := config.get("signals"):
+            self.wifi_strength = signals.get("wifi")
+            self.battery_voltage = signals.get("battery")
+            self.sync_signal = signals.get("lfr")
+        else:
+            self.wifi_strength = config.get("wifi_strength")
+            self.battery_voltage = config.get("battery_voltage")
+
+        self.product_type = config.get("type")
 
     async def get_sensor_info(self):
         """Retrieve calibrated temperature from special endpoint."""

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -80,7 +80,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         self.assertEqual(self.camera.temperature, 68)
         self.assertEqual(self.camera.temperature_c, 20)
         self.assertEqual(self.camera.temperature_calibrated, 71)
-        self.assertEqual(self.camera.wifi_strength, 4)
+        self.assertEqual(self.camera.wifi_strength, 80)
         self.assertEqual(
             self.camera.thumbnail, "https://rest-test.immedia-semi.com/thumb.jpg"
         )

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -80,7 +80,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         self.assertEqual(self.camera.temperature, 68)
         self.assertEqual(self.camera.temperature_c, 20)
         self.assertEqual(self.camera.temperature_calibrated, 71)
-        self.assertEqual(self.camera.wifi_strength, 80)
+        self.assertEqual(self.camera.wifi_strength, 4)
         self.assertEqual(
             self.camera.thumbnail, "https://rest-test.immedia-semi.com/thumb.jpg"
         )

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -408,3 +408,26 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             in "\t".join(dl_log.output)
         )
         assert mock_open.call_count == 1
+
+    async def test_missing_keys(self, mock_resp):
+        """Tests missing signal keys."""
+        config = {
+            "name": "new",
+            "id": 1234,
+            "network_id": 5678,
+            "serial": "12345678",
+            "enabled": False,
+            "battery_state": "ok",
+            "temperature": 68,
+            "signals": {"junk": 1},
+            "thumbnail": "",
+        }
+        self.camera.sync.homescreen = {"devices": []}
+        mock_resp.side_effect = [
+            {"temp": 71},
+            mresp.MockResponse({"test": 200}, 200, raw_data="test"),
+            mresp.MockResponse({"foobar": 200}, 200, raw_data="foobar"),
+        ]
+        await self.camera.update(config, expire_clips=False, force=True)
+        self.assertEqual(self.camera.wifi_strength, None)
+        self.assertEqual(self.camera.battery_voltage, None)

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -56,7 +56,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "battery_voltage": 90,
             "battery_state": "ok",
             "temperature": 68,
-            "wifi_strength": 4,
+            "signals": {"lfr":5,"wifi":4,"battery":3},
             "thumbnail": "/thumb",
         }
         self.camera.last_record = ["1"]

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -56,7 +56,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "battery_voltage": 90,
             "battery_state": "ok",
             "temperature": 68,
-            "signals": {"lfr":5,"wifi":4,"battery":3},
+            "signals": {"lfr": 5, "wifi": 4, "battery": 3},
             "thumbnail": "/thumb",
         }
         self.camera.last_record = ["1"]


### PR DESCRIPTION
## Description:
The API has changed - appears the wifi_strength and battery_voltage keys have been removed and a new key:
`signals:{'lfr': 5, 'wifi': 4, 'battery': 3}` has been added.
If the new key (signals) exists, we populate the values using the sub keys, if not, fall back to previous key names.
Add "sync_signal_strength" to attributes.

~~I'm not sure if the original wifi_strength key was 0-5 or actual signal strength (I think was was signal strength). 
I suppose we need to change the HA side to not show dBm?  Should we do a percentage (5/5 = 100%, 1/5 - 20%) or maybe do this on the HA side?~~

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>
https://github.com/home-assistant/core/issues/106509

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
