### PR TITLE
Battery level

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -28,7 +28,7 @@ class BlinkCamera:
         self.thumbnail = None
         self.serial = None
         self.motion_enabled = None
-        self.battery_voltage = None
+        self.battery_level = None
         self.clip = None
         # A clip remains in the recent clips list until is has
         # been downloaded or has been expired.
@@ -56,7 +56,7 @@ class BlinkCamera:
             "temperature_c": self.temperature_c,
             "temperature_calibrated": self.temperature_calibrated,
             "battery": self.battery,
-            "battery_voltage": self.battery_voltage,
+            "battery_level": self.battery_level,
             "thumbnail": self.thumbnail,
             "video": self.clip,
             "recent_clips": self.recent_clips,
@@ -237,12 +237,10 @@ class BlinkCamera:
         self.temperature = config.get("temperature")
         if signals := config.get("signals"):
             self.wifi_strength = signals.get("wifi")
-            self.battery_voltage = signals.get("battery")
+            self.battery_level = signals.get("battery")
             self.sync_signal_strength = signals.get("lfr")
         else:
             self.wifi_strength = config.get("wifi_strength")
-            self.battery_voltage = config.get("battery_voltage")
-
         self.product_type = config.get("type")
 
     async def get_sensor_info(self):

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -18,7 +18,7 @@ import tests.mock_responses as mresp
 CAMERA_CFG = {
     "camera": [
         {
-            "battery_voltage": 90,
+            "battery_level": 5,
             "motion_alert": True,
             "wifi_strength": -30,
             "temperature": 68,
@@ -53,7 +53,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "network_id": 5678,
             "serial": "12345678",
             "enabled": False,
-            "battery_voltage": 90,
+            "battery_level": 5,
             "battery_state": "ok",
             "temperature": 68,
             "signals": {"lfr": 5, "wifi": 4, "battery": 3},
@@ -112,7 +112,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "network_id": 5678,
             "serial": "12345678",
             "enabled": False,
-            "battery_voltage": 90,
+            "battery_level": 90,
             "battery_state": "ok",
             "temperature": 68,
             "wifi_strength": 4,
@@ -149,7 +149,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "network_id": 5678,
             "serial": "12345678",
             "enabled": False,
-            "battery_voltage": 90,
+            "battery_level": 90,
             "battery_state": "ok",
             "temperature": 68,
             "wifi_strength": 4,
@@ -173,7 +173,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "network_id": 5678,
             "serial": "12345678",
             "enabled": False,
-            "battery_voltage": 90,
+            "battery_level": 5,
             "battery_state": "ok",
             "temperature": 68,
             "wifi_strength": 4,
@@ -199,7 +199,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "network_id": 5678,
             "serial": "12345678",
             "enabled": False,
-            "battery_voltage": 90,
+            "battery_level": 5,
             "battery_state": "ok",
             "temperature": 68,
             "wifi_strength": 4,
@@ -430,4 +430,4 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         ]
         await self.camera.update(config, expire_clips=False, force=True)
         self.assertEqual(self.camera.wifi_strength, None)
-        self.assertEqual(self.camera.battery_voltage, None)
+        self.assertEqual(self.camera.battery_level, None)

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -21,12 +21,12 @@ CONFIG = {
     "network_id": 5678,
     "serial": "12345678",
     "enabled": False,
-    "battery_level": 5,
     "battery_state": "ok",
     "temperature": 68,
     "signals": {"lfr": 5, "wifi": 4, "battery": 3},
     "thumbnail": "/thumb",
 }
+
 
 @mock.patch("blinkpy.auth.Auth.query")
 class TestBlinkCameraSetup(IsolatedAsyncioTestCase):

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -95,10 +95,9 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         """Tests that thumbnail is 'None' if none found."""
         mock_resp.return_value = "foobar"
         self.camera.last_record = ["1"]
-        config = CONFIG
-        config.update({
+        config = CONFIG | {
             "thumbnail": "",
-        })
+        }
 
         self.camera.sync.homescreen = {"devices": []}
         self.assertEqual(self.camera.temperature_calibrated, None)
@@ -125,10 +124,9 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
     async def test_no_video_clips(self, mock_resp):
         """Tests that we still proceed with camera setup with no videos."""
         mock_resp.return_value = "foobar"
-        config = CONFIG
-        config.update({
+        config = CONFIG | {
             "thumbnail": "/foobar",
-        })
+        }
         mock_resp.return_value = mresp.MockResponse({"test": 200}, 200, raw_data="")
         self.camera.sync.homescreen = {"devices": []}
         await self.camera.update(config, force_cache=True, expire_clips=False)
@@ -141,17 +139,13 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         Tests that the last records in the sync module are added
         to the camera recent clips list.
         """
-        config = CONFIG
-        config.update({
-            "thumbnail": "/thumb",
-        })
         self.camera.sync.last_records["foobar"] = []
         record2 = {"clip": "/clip2", "time": "2022-12-01 00:00:10+00:00"}
         self.camera.sync.last_records["foobar"].append(record2)
         record1 = {"clip": "/clip1", "time": "2022-12-01 00:00:00+00:00"}
         self.camera.sync.last_records["foobar"].append(record1)
         self.camera.sync.motion["foobar"] = True
-        await self.camera.update_images(config, expire_clips=False)
+        await self.camera.update_images(CONFIG, expire_clips=False)
         record1["clip"] = self.blink.urls.base_url + "/clip1"
         record2["clip"] = self.blink.urls.base_url + "/clip2"
         self.assertEqual(self.camera.recent_clips[0], record1)
@@ -365,11 +359,10 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     async def test_missing_keys(self, mock_resp):
         """Tests missing signal keys."""
-        config = CONFIG
-        config.update({
+        config = CONFIG | {
             "signals": {"junk": 1},
             "thumbnail": "",
-        })
+        }
         self.camera.sync.homescreen = {"devices": []}
         mock_resp.side_effect = [
             {"temp": 71},

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -95,8 +95,11 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         """Tests that thumbnail is 'None' if none found."""
         mock_resp.return_value = "foobar"
         self.camera.last_record = ["1"]
-        config = CONFIG | {
-            "thumbnail": "",
+        config = {
+            **CONFIG,
+            **{
+                "thumbnail": "",
+            },
         }
 
         self.camera.sync.homescreen = {"devices": []}
@@ -124,8 +127,11 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
     async def test_no_video_clips(self, mock_resp):
         """Tests that we still proceed with camera setup with no videos."""
         mock_resp.return_value = "foobar"
-        config = CONFIG | {
-            "thumbnail": "/foobar",
+        config = {
+            **CONFIG,
+            **{
+                "thumbnail": "/foobar",
+            },
         }
         mock_resp.return_value = mresp.MockResponse({"test": 200}, 200, raw_data="")
         self.camera.sync.homescreen = {"devices": []}
@@ -359,9 +365,12 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     async def test_missing_keys(self, mock_resp):
         """Tests missing signal keys."""
-        config = CONFIG | {
-            "signals": {"junk": 1},
-            "thumbnail": "",
+        config = {
+            **CONFIG,
+            **{
+                "signals": {"junk": 1},
+                "thumbnail": "",
+            },
         }
         self.camera.sync.homescreen = {"devices": []}
         mock_resp.side_effect = [

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -15,17 +15,18 @@ from blinkpy.sync_module import BlinkSyncModule
 from blinkpy.camera import BlinkCamera, BlinkCameraMini, BlinkDoorbell
 import tests.mock_responses as mresp
 
-CAMERA_CFG = {
-    "camera": [
-        {
-            "battery_level": 5,
-            "motion_alert": True,
-            "wifi_strength": -30,
-            "temperature": 68,
-        }
-    ]
+CONFIG = {
+    "name": "new",
+    "id": 1234,
+    "network_id": 5678,
+    "serial": "12345678",
+    "enabled": False,
+    "battery_level": 5,
+    "battery_state": "ok",
+    "temperature": 68,
+    "signals": {"lfr": 5, "wifi": 4, "battery": 3},
+    "thumbnail": "/thumb",
 }
-
 
 @mock.patch("blinkpy.auth.Auth.query")
 class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
@@ -47,18 +48,6 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     async def test_camera_update(self, mock_resp):
         """Test that we can properly update camera properties."""
-        config = {
-            "name": "new",
-            "id": 1234,
-            "network_id": 5678,
-            "serial": "12345678",
-            "enabled": False,
-            "battery_level": 5,
-            "battery_state": "ok",
-            "temperature": 68,
-            "signals": {"lfr": 5, "wifi": 4, "battery": 3},
-            "thumbnail": "/thumb",
-        }
         self.camera.last_record = ["1"]
         self.camera.sync.last_records = {
             "new": [{"clip": "/test.mp4", "time": "1970-01-01T00:00:00"}]
@@ -70,7 +59,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         ]
         self.assertIsNone(self.camera.image_from_cache)
 
-        await self.camera.update(config, expire_clips=False)
+        await self.camera.update(CONFIG, expire_clips=False)
         self.assertEqual(self.camera.name, "new")
         self.assertEqual(self.camera.camera_id, "1234")
         self.assertEqual(self.camera.network_id, "5678")
@@ -106,18 +95,11 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         """Tests that thumbnail is 'None' if none found."""
         mock_resp.return_value = "foobar"
         self.camera.last_record = ["1"]
-        config = {
-            "name": "new",
-            "id": 1234,
-            "network_id": 5678,
-            "serial": "12345678",
-            "enabled": False,
-            "battery_level": 90,
-            "battery_state": "ok",
-            "temperature": 68,
-            "wifi_strength": 4,
+        config = CONFIG
+        config.update({
             "thumbnail": "",
-        }
+        })
+
         self.camera.sync.homescreen = {"devices": []}
         self.assertEqual(self.camera.temperature_calibrated, None)
         with self.assertLogs() as logrecord:
@@ -143,18 +125,10 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
     async def test_no_video_clips(self, mock_resp):
         """Tests that we still proceed with camera setup with no videos."""
         mock_resp.return_value = "foobar"
-        config = {
-            "name": "new",
-            "id": 1234,
-            "network_id": 5678,
-            "serial": "12345678",
-            "enabled": False,
-            "battery_level": 90,
-            "battery_state": "ok",
-            "temperature": 68,
-            "wifi_strength": 4,
+        config = CONFIG
+        config.update({
             "thumbnail": "/foobar",
-        }
+        })
         mock_resp.return_value = mresp.MockResponse({"test": 200}, 200, raw_data="")
         self.camera.sync.homescreen = {"devices": []}
         await self.camera.update(config, force_cache=True, expire_clips=False)
@@ -167,18 +141,10 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         Tests that the last records in the sync module are added
         to the camera recent clips list.
         """
-        config = {
-            "name": "new",
-            "id": 1234,
-            "network_id": 5678,
-            "serial": "12345678",
-            "enabled": False,
-            "battery_level": 5,
-            "battery_state": "ok",
-            "temperature": 68,
-            "wifi_strength": 4,
+        config = CONFIG
+        config.update({
             "thumbnail": "/thumb",
-        }
+        })
         self.camera.sync.last_records["foobar"] = []
         record2 = {"clip": "/clip2", "time": "2022-12-01 00:00:10+00:00"}
         self.camera.sync.last_records["foobar"].append(record2)
@@ -193,25 +159,13 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     async def test_recent_video_clips_missing_key(self, mock_resp):
         """Tests that the missing key failst."""
-        config = {
-            "name": "new",
-            "id": 1234,
-            "network_id": 5678,
-            "serial": "12345678",
-            "enabled": False,
-            "battery_level": 5,
-            "battery_state": "ok",
-            "temperature": 68,
-            "wifi_strength": 4,
-            "thumbnail": "/thumb",
-        }
         self.camera.sync.last_records["foobar"] = []
         record2 = {"clip": "/clip2"}
         self.camera.sync.last_records["foobar"].append(record2)
         self.camera.sync.motion["foobar"] = True
 
         with self.assertLogs(level="ERROR") as dl_log:
-            await self.camera.update_images(config, expire_clips=False)
+            await self.camera.update_images(CONFIG, expire_clips=False)
 
         self.assertIsNotNone(dl_log.output)
 
@@ -411,17 +365,11 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     async def test_missing_keys(self, mock_resp):
         """Tests missing signal keys."""
-        config = {
-            "name": "new",
-            "id": 1234,
-            "network_id": 5678,
-            "serial": "12345678",
-            "enabled": False,
-            "battery_state": "ok",
-            "temperature": 68,
+        config = CONFIG
+        config.update({
             "signals": {"junk": 1},
             "thumbnail": "",
-        }
+        })
         self.camera.sync.homescreen = {"devices": []}
         mock_resp.side_effect = [
             {"temp": 71},

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -14,15 +14,17 @@ from blinkpy.sync_module import BlinkSyncModule
 from blinkpy.camera import BlinkCamera, BlinkCameraMini, BlinkDoorbell
 import tests.mock_responses as mresp
 
-CAMERA_CFG = {
-    "camera": [
-        {
-            "battery_level": 5,
-            "motion_alert": True,
-            "wifi_strength": -30,
-            "temperature": 68,
-        }
-    ]
+CONFIG = {
+    "name": "new",
+    "id": 1234,
+    "network_id": 5678,
+    "serial": "12345678",
+    "enabled": False,
+    "battery_state": "ok",
+    "temperature": 68,
+    "thumbnail": 1357924680,
+    "signals": {"lfr": 5, "wifi": 4, "battery": 3},
+    "type": "test",
 }
 
 
@@ -128,41 +130,18 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
     async def test_different_thumb_api(self, mock_resp):
         """Test that the correct url is created with new api."""
         thumb_endpoint = "https://rest-test.immedia-semi.com/api/v3/media/accounts/9999/networks/5678/test/1234/thumbnail/thumbnail.jpg?ts=1357924680&ext="
-        config = {
-            "name": "new",
-            "id": 1234,
-            "network_id": 5678,
-            "serial": "12345678",
-            "enabled": False,
-            "battery_level": 5,
-            "battery_state": "ok",
-            "temperature": 68,
-            "wifi_strength": 4,
-            "thumbnail": 1357924680,
-            "type": "test",
-        }
         mock_resp.side_effect = [
             {"temp": 71},
             mresp.MockResponse({"test": 200}, 200, raw_data="test"),
         ]
         self.camera.sync.blink.account_id = 9999
-        await self.camera.update(config, expire_clips=False)
+        await self.camera.update(CONFIG, expire_clips=False)
         self.assertEqual(self.camera.thumbnail, thumb_endpoint)
 
     async def test_thumb_return_none(self, mock_resp):
         """Test that a 'None" thumbnail is doesn't break system."""
-        config = {
-            "name": "new",
-            "id": 1234,
-            "network_id": 5678,
-            "serial": "12345678",
-            "enabled": False,
-            "battery_level": 5,
-            "battery_state": "ok",
-            "temperature": 68,
-            "wifi_strength": 4,
-            "thumbnail": None,
-            "type": "test",
+        config = CONFIG | {
+            "thumbnail": None,   
         }
         mock_resp.side_effect = [
             {"temp": 71},
@@ -177,18 +156,8 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "/api/v3/media/accounts/9999/networks/5678/"
             "test/1234/thumbnail/thumbnail.jpg?ts=1357924680&ext="
         )
-        config = {
-            "name": "new",
-            "id": 1234,
-            "network_id": 5678,
-            "serial": "12345678",
-            "enabled": False,
-            "battery_level": 5,
-            "battery_state": "ok",
-            "temperature": 68,
-            "wifi_strength": 4,
+        config = CONFIG | {
             "thumbnail": thumb_return,
-            "type": "test",
         }
         mock_resp.side_effect = [
             {"temp": 71},

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -141,7 +141,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
     async def test_thumb_return_none(self, mock_resp):
         """Test that a 'None" thumbnail is doesn't break system."""
         config = CONFIG | {
-            "thumbnail": None,   
+            "thumbnail": None,
         }
         mock_resp.side_effect = [
             {"temp": 71},

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -140,8 +140,11 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     async def test_thumb_return_none(self, mock_resp):
         """Test that a 'None" thumbnail is doesn't break system."""
-        config = CONFIG | {
-            "thumbnail": None,
+        config = {
+            **CONFIG,
+            **{
+                "thumbnail": None,
+            },
         }
         mock_resp.side_effect = [
             {"temp": 71},
@@ -156,8 +159,11 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "/api/v3/media/accounts/9999/networks/5678/"
             "test/1234/thumbnail/thumbnail.jpg?ts=1357924680&ext="
         )
-        config = CONFIG | {
-            "thumbnail": thumb_return,
+        config = {
+            **CONFIG,
+            **{
+                "thumbnail": thumb_return,
+            },
         }
         mock_resp.side_effect = [
             {"temp": 71},

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -17,7 +17,7 @@ import tests.mock_responses as mresp
 CAMERA_CFG = {
     "camera": [
         {
-            "battery_voltage": 90,
+            "battery_level": 5,
             "motion_alert": True,
             "wifi_strength": -30,
             "temperature": 68,
@@ -134,7 +134,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "network_id": 5678,
             "serial": "12345678",
             "enabled": False,
-            "battery_voltage": 90,
+            "battery_level": 5,
             "battery_state": "ok",
             "temperature": 68,
             "wifi_strength": 4,
@@ -157,7 +157,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "network_id": 5678,
             "serial": "12345678",
             "enabled": False,
-            "battery_voltage": 90,
+            "battery_level": 5,
             "battery_state": "ok",
             "temperature": 68,
             "wifi_strength": 4,
@@ -183,7 +183,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "network_id": 5678,
             "serial": "12345678",
             "enabled": False,
-            "battery_voltage": 90,
+            "battery_level": 5,
             "battery_state": "ok",
             "temperature": 68,
             "wifi_strength": 4,


### PR DESCRIPTION
## Description:
Change name of `battery_voltage` to `battery_level`
Update camera tests and utilize constant for `CONFIG`

- This PR has commits from https://github.com/fronzbot/blinkpy/pull/835.  I will rebase if necessary after 835 is merged.

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
