### PR TITLE
Address not awaited warning

### DIFF
--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -27,7 +27,7 @@ CAMERA_CFG = {
 }
 
 
-@mock.patch("blinkpy.auth.Auth.query")
+@mock.patch("blinkpy.auth.Auth.query", return_value={})
 class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
     """Test the Blink class in blinkpy."""
 

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -26,7 +26,7 @@ CAMERA_CFG = {
 }
 
 
-@mock.patch("blinkpy.auth.Auth.query")
+@mock.patch("blinkpy.auth.Auth.query", return_value={})
 class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
     """Test the Blink class in blinkpy."""
 

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -22,7 +22,7 @@ logging.basicConfig(filename="blinkpy_test.log", level=logging.DEBUG)
 _LOGGER.setLevel(logging.DEBUG)
 
 
-@mock.patch("blinkpy.auth.Auth.query")
+@mock.patch("blinkpy.auth.Auth.query", return_value={"status": 200})
 class TestBlinkSyncModule(IsolatedAsyncioTestCase):
     """Test BlinkSyncModule functions in blinkpy."""
 


### PR DESCRIPTION
## Description:
Due to a patching "error" the tests were throwing a never awaited warning.  The return value should not have been an awaitable object.

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
