### PR TITLE
Catch `ContentTypeError` in 2FA

### DIFF
--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -1,6 +1,6 @@
 """Login handler for blink."""
 import logging
-from aiohttp import ClientSession, ClientConnectionError
+from aiohttp import ClientSession, ClientConnectionError, ContentTypeError
 from blinkpy import api
 from blinkpy.helpers import util
 from blinkpy.helpers.constants import (
@@ -220,7 +220,7 @@ class Auth:
                 if not blink.available:
                     _LOGGER.error("%s", json_resp["message"])
                     return False
-            except (KeyError, TypeError):
+            except (KeyError, TypeError, ContentTypeError):
                 _LOGGER.error("Did not receive valid response from server.")
                 return False
         return True


### PR DESCRIPTION
## Description:
Appears sometimes non JSON is returned in 2FA and not caught.
https://github.com/home-assistant/core/issues/107143
This does not address the root problem - text instead of JSON response.

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be merged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
