### PR TITLE
Handle Emtpy put response in wait_command

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -503,8 +503,11 @@ async def http_post(blink, url, is_retry=False, data=None, json=True, timeout=TI
 async def wait_for_command(blink, json_data: dict) -> bool:
     """Wait for command to complete."""
     _LOGGER.debug("Command Wait %s", json_data)
-    network_id = json_data.get("network_id")
-    command_id = json_data.get("id")
+    try:
+        network_id = json_data.get("network_id")
+        command_id = json_data.get("id")
+    except AttributeError:
+        return False
     if command_id and network_id:
         for _ in range(0, MAX_RETRY):
             _LOGGER.debug("Making GET request waiting for command")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -183,3 +183,6 @@ class TestAPI(IsolatedAsyncioTestCase):
         mock_resp.side_effect = (COMMAND_COMPLETE_BAD, {})
         response = await api.wait_for_command(self.blink, COMMAND_RESPONSE)
         self.assertFalse(response)
+
+        response = await api.wait_for_command(self.blink, {})
+        self.assertFalse(response)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -184,5 +184,5 @@ class TestAPI(IsolatedAsyncioTestCase):
         response = await api.wait_for_command(self.blink, COMMAND_RESPONSE)
         self.assertFalse(response)
 
-        response = await api.wait_for_command(self.blink, {})
+        response = await api.wait_for_command(self.blink, None)
         self.assertFalse(response)


### PR DESCRIPTION
## Description:

Some put responses return empty set or missing keys which was not handled by `wait_command()`

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
