### PR TITLE
fix/ha integration status becomes unvailable when requesting api

### DIFF
--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -21,9 +21,9 @@ ONLINE = {"online": True, "offline": False}
 OTHER
 """
 DEFAULT_USER_AGENT = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) "
+    "Mozilla/5.0 (Linux; Android 14) "
     "AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/71.0.3578.98 Safari/537.36"
+    "Chrome/120.0.6099.193 Mobile Safari/537.36"
 )
 DEVICE_ID = "Blinkpy"
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S%z"


### PR DESCRIPTION
## Description:

Blink integration in HA becomes unavailable when requesting API through differents actions, like Arming, Disarming, Updating...

Entries in log journal are similar to the entry below, and the number of ocurrences depends on how often the API is requested.

```
ERROR (MainThread) [homeassistant.components.blink.coordinator] Error requesting blink data: 0, message='Attempt to decode JSON with unexpected mimetype: text/plain; charset=utf-8', url=URL('https://***')
```

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [X] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [X] Changes tested locally to ensure platform still works as intended
- [X] Tests added to verify new code works
