### PR TITLE
Add properties for version information

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -27,7 +27,7 @@ class BlinkCamera:
         self.network_id = None
         self.thumbnail = None
         self.serial = None
-        self.version = None
+        self._version = None
         self.motion_enabled = None
         self.battery_level = None
         self.clip = None
@@ -53,7 +53,7 @@ class BlinkCamera:
             "name": self.name,
             "camera_id": self.camera_id,
             "serial": self.serial,
-            "version": self.version,
+            "version": self._version,
             "temperature": self.temperature,
             "temperature_c": self.temperature_c,
             "temperature_calibrated": self.temperature_calibrated,
@@ -99,6 +99,11 @@ class BlinkCamera:
         if self._cached_video:
             return self._cached_video
         return None
+
+    @property
+    def version(self):
+        """Return the camera Firmware version."""
+        return self._version
 
     @property
     def arm(self):
@@ -234,7 +239,7 @@ class BlinkCamera:
         self.camera_id = str(config.get("id", "unknown"))
         self.network_id = str(config.get("network_id", "unknown"))
         self.serial = config.get("serial")
-        self.version = config.get("fw_version")
+        self._version = config.get("fw_version")
         self.motion_enabled = config.get("enabled", "unknown")
         self.battery_state = config.get("battery_state") or config.get("battery")
         self.temperature = config.get("temperature")

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -34,7 +34,7 @@ class BlinkSyncModule:
         self.region_id = blink.auth.region_id
         self.name = network_name
         self.serial = None
-        self.version = None
+        self._version = None
         self.status = "offline"
         self.sync_id = None
         self.host = None
@@ -73,7 +73,7 @@ class BlinkSyncModule:
             "id": self.sync_id,
             "network_id": self.network_id,
             "serial": self.serial,
-            "version": self.version,
+            "version": self._version,
             "status": self.status,
             "region_id": self.region_id,
             "local_storage": self.local_storage,
@@ -94,6 +94,11 @@ class BlinkSyncModule:
             _LOGGER.error("Unknown sync module status %s", self.status)
             self.available = False
             return False
+
+    @property
+    def version(self):
+        """Return the Syncmodule Firmware version."""
+        return self._version
 
     @property
     def arm(self):
@@ -155,7 +160,7 @@ class BlinkSyncModule:
                 "Could not retrieve sync module information with response: %s", response
             )
             return False
-        self.version = self.summary.get("fw_version")
+        self._version = self.summary.get("fw_version")
         return response
 
     async def _init_local_storage(self, sync_id):

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -89,10 +89,13 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         """Test that attributes return None if missing."""
         self.camera.temperature = None
         self.camera.serial = None
+        self.camera._version = None
         attr = self.camera.attributes
         self.assertEqual(attr["serial"], None)
         self.assertEqual(attr["temperature"], None)
         self.assertEqual(attr["temperature_c"], None)
+        self.assertEqual(attr["version"],None)
+        self.assertEqual(self.camera.version,None)
 
     def test_mini_missing_attributes(self, mock_resp):
         """Test that attributes return None if missing."""

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -128,6 +128,7 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         self.assertEqual(
             await self.blink.sync["test"].get_camera_info("1234"), "foobar"
         )
+        self.assertEqual(self.blink.sync["test"].version,None)
 
     async def test_get_camera_info_fail(self, mock_resp) -> None:
         """Test handling of failed get camera info function."""


### PR DESCRIPTION
## Description:
Finish the version information allowing HA to utilize the values

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
