### PR TITLE
Test for None type in poll_local_storage_manifest

### DIFF
--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -501,14 +501,14 @@ class BlinkSyncModule:
                 response = await api.request_local_storage_manifest(
                     self.blink, self.network_id, self.sync_id
                 )
-                if "id" in response:
+                if response and "id" in response:
                     break
             # Get the manifest.
             else:
                 response = await api.get_local_storage_manifest(
                     self.blink, self.network_id, self.sync_id, manifest_request_id
                 )
-                if "clips" in response:
+                if response and "clips" in response:
                     break
             seconds = backoff_seconds(retry=retry, default_time=3)
             _LOGGER.debug("[retry=%d] Retrying in %d seconds", retry + 1, seconds)


### PR DESCRIPTION
## Description:

When 406 errors are received, poll_local_storage_manifest fails with None type.  Add test to prevent this failure

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>
https://github.com/home-assistant/core/issues/107143#issuecomment-1889960412

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
