### PR TITLE
Add option to change agent from Auth() init

### DIFF
--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -22,7 +22,14 @@ _LOGGER = logging.getLogger(__name__)
 class Auth:
     """Class to handle login communication."""
 
-    def __init__(self, login_data=None, no_prompt=False, session=None):
+    def __init__(
+        self,
+        login_data=None,
+        no_prompt=False,
+        session=None,
+        agent=DEFAULT_USER_AGENT,
+        app_build=APP_BUILD,
+    ):
         """
         Initialize auth handler.
 
@@ -44,10 +51,9 @@ class Auth:
         self.login_response = None
         self.is_errored = False
         self.no_prompt = no_prompt
-        if session:
-            self.session = session
-        else:
-            self.session = ClientSession()
+        self._agent = agent
+        self._app_build = app_build
+        self.session = session if session else ClientSession()
 
     @property
     def login_attributes(self):
@@ -65,9 +71,9 @@ class Auth:
         if self.token is None:
             return None
         return {
-            "APP-BUILD": APP_BUILD,
+            "APP-BUILD": self._app_build,
             "TOKEN_AUTH": self.token,
-            "User-Agent": DEFAULT_USER_AGENT,
+            "User-Agent": self._agent,
             "Content-Type": "application/json",
         }
 


### PR DESCRIPTION
## Description:
A little forward thinking (maybe) - allow calling app to set agent and app_build as optional keys.
I have a feeling we will need to change this more often than not.

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
