### PR TITLE
Update image after snap

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -206,9 +206,14 @@ class BlinkCamera:
 
     async def snap_picture(self):
         """Take a picture with camera to create a new thumbnail."""
-        return await api.request_new_image(
+        ret_val = await api.request_new_image(
             self.sync.blink, self.network_id, self.camera_id
         )
+        response = await self.get_media()
+        if response and response.status == 200:
+            self._cached_image = await response.read()
+
+        return ret_val
 
     async def set_motion_detect(self, enable):
         """Set motion detection."""


### PR DESCRIPTION
## Description:
This should address the long delay in updating images after a snap, allowing the removal of line 129 (which apparently isn't doing what I thought it should):
https://github.com/home-assistant/core/blob/45fec1d4048c72ef94df027154ecf7bf69c21c84/homeassistant/components/blink/camera.py#L128-L130
and reduce the number of update calls made to Blink.

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
