### PR TITLE
Restore camera battery_voltage and wifi_strength

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -85,7 +85,7 @@ You can then run all of the tests with the following command:
 
 **Tips**
 
-If you only want to see if you can pass the local tests, you can run ``tox -e py37`` (or whatever python version you have installed.  Only ``py36``, ``py37``, and ``py38`` will be accepted).  If you just want to check for style violations, you can run ``tox -e lint``.  Regardless, when you submit a pull request, your code MUST pass both the unit tests, and the linters.
+If you only want to see if you can pass the local tests, you can run ``tox -e py39`` (or whatever python version you have installed.  Only ``py39`` through ``py312`` will be accepted).  If you just want to check for style violations, you can run ``tox -e lint``.  Regardless, when you submit a pull request, your code MUST pass both the unit tests, and the linters.
 
 If you need to change anything in ``requirements.txt`` for any reason, you'll want to regenerate the virtual envrionments used by ``tox`` by running with the ``-r`` flag: ``tox -r``
 
@@ -104,7 +104,7 @@ If your code is taking a while to develop, you may be behind the ``dev`` branch,
 
 If rebase detects conflicts, repeat the following process until all changes have been resolved:
 
-1. ``git status`` shows you the filw with a conflict.  You will need to edit that file and resolve the lines between ``<<<< | >>>>``.
+1. ``git status`` shows you the file with a conflict.  You will need to edit that file and resolve the lines between ``<<<< | >>>>``.
 2. Add the modified file: ``git add <file>`` or ``git add .``.
 3. Continue rebase: ``git rebase --continue``.
 4. Repeat until all conflicts resolved.

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -30,7 +30,7 @@ class BlinkCamera:
         self._version = None
         self.motion_enabled = None
         self.battery_level = None
-        self.battery_voltage = None
+        self._battery_voltage = None
         self.clip = None
         # A clip remains in the recent clips list until is has
         # been downloaded or has been expired.
@@ -60,7 +60,7 @@ class BlinkCamera:
             "temperature_calibrated": self.temperature_calibrated,
             "battery": self.battery,
             "battery_level": self.battery_level,
-            "battery_voltage": self.battery_voltage,
+            "battery_voltage": self._battery_voltage,
             "thumbnail": self.thumbnail,
             "video": self.clip,
             "recent_clips": self.recent_clips,
@@ -79,6 +79,11 @@ class BlinkCamera:
     def battery(self):
         """Return battery as string."""
         return self.battery_state
+
+    @property
+    def battery_voltage(self):
+        """Return battery voltage as a number in 100ths of volts, e.g. 165 means 1.65v."""
+        return self._battery_voltage
 
     @property
     def temperature_c(self):
@@ -248,7 +253,7 @@ class BlinkCamera:
         self.serial = config.get("serial")
         self._version = config.get("fw_version")
         self.motion_enabled = config.get("enabled", "unknown")
-        self.battery_voltage = config.get("battery_voltage", None)
+        self._battery_voltage = config.get("battery_voltage", None)
         self.battery_state = config.get("battery_state") or config.get("battery")
         self.wifi_strength = config.get("wifi_strength")
         if signals := config.get("signals"):

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -30,6 +30,7 @@ class BlinkCamera:
         self._version = None
         self.motion_enabled = None
         self.battery_level = None
+        self.battery_voltage = None
         self.clip = None
         # A clip remains in the recent clips list until is has
         # been downloaded or has been expired.
@@ -59,6 +60,7 @@ class BlinkCamera:
             "temperature_calibrated": self.temperature_calibrated,
             "battery": self.battery,
             "battery_level": self.battery_level,
+            "battery_voltage": self.battery_voltage,
             "thumbnail": self.thumbnail,
             "video": self.clip,
             "recent_clips": self.recent_clips,
@@ -246,14 +248,14 @@ class BlinkCamera:
         self.serial = config.get("serial")
         self._version = config.get("fw_version")
         self.motion_enabled = config.get("enabled", "unknown")
+        self.battery_voltage = config.get("battery_voltage", None)
         self.battery_state = config.get("battery_state") or config.get("battery")
+        self.wifi_strength = config.get("wifi_strength")
         if signals := config.get("signals"):
-            self.wifi_strength = signals.get("wifi")
             self.battery_level = signals.get("battery")
             self.sync_signal_strength = signals.get("lfr")
             self.temperature = signals.get("temp")
         else:
-            self.wifi_strength = config.get("wifi_strength")
             self.temperature = config.get("temperature")
         self.product_type = config.get("type")
 

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -82,7 +82,7 @@ class BlinkCamera:
 
     @property
     def battery_voltage(self):
-        """Return battery voltage as a number in 100ths of volts, e.g. 165 means 1.65v."""
+        """Return battery voltage as a number in 100ths of volts, so 165 = 1.65v."""
         return self._battery_voltage
 
     @property

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -49,10 +49,11 @@ class BlinkSyncModule:
         self.last_records = {}
         self.camera_list = camera_list
         self.available = False
+        # type_key_map is only for the mini's and the doorbells.
+        # Outdoor cameras have their own URL API which must be queried.
         self.type_key_map = {
             "mini": "owls",
             "doorbell": "doorbells",
-            "outdoor": "cameras",
         }
         self._names_table = {}
         self._local_storage = {

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -381,5 +381,4 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             mresp.MockResponse({"foobar": 200}, 200, raw_data="foobar"),
         ]
         await self.camera.update(config, expire_clips=False, force=True)
-        self.assertEqual(self.camera.wifi_strength, None)
         self.assertEqual(self.camera.battery_level, None)

--- a/tests/test_camera_functions.py
+++ b/tests/test_camera_functions.py
@@ -22,6 +22,8 @@ CONFIG = {
     "serial": "12345678",
     "enabled": False,
     "battery_state": "ok",
+    "battery_voltage": 163,
+    "wifi_strength": -38,
     "signals": {"lfr": 5, "wifi": 4, "battery": 3, "temp": 68},
     "thumbnail": "/thumb",
 }
@@ -68,7 +70,8 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         self.assertEqual(self.camera.temperature, 68)
         self.assertEqual(self.camera.temperature_c, 20)
         self.assertEqual(self.camera.temperature_calibrated, 71)
-        self.assertEqual(self.camera.wifi_strength, 4)
+        self.assertEqual(self.camera.battery_voltage, 163)
+        self.assertEqual(self.camera.wifi_strength, -38)
         self.assertEqual(
             self.camera.thumbnail, "https://rest-test.immedia-semi.com/thumb.jpg"
         )


### PR DESCRIPTION
## Description:
Full cameras (outdoor XT, XT2, and indoor) lost their battery voltage and wifi_strength fields in release v0.22.5. Due to a logic bug, these cameras no longer had their REST API queried for their full set of information; only the "base" information contained on the "home screen" was being stored.
This should restore the REST API call, and those fields should appear again.

**Related issue:** fixes #865 

Alas, a number of "downstream" changes were made in v0.22.6 which possibly need to be reverted, now that the "full camera attributes" are available again.
Consider looking at changes made in #835, #837, and #867.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
