### PR TITLE
Aiofiles import cleanup, fix warnings in pyproject.toml

### DIFF
--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -16,8 +16,7 @@ import os.path
 import time
 import logging
 import datetime
-from aiofiles import ospath, open
-
+import aiofiles
 from requests.structures import CaseInsensitiveDict
 from dateutil.parser import parse
 from slugify import slugify
@@ -413,12 +412,12 @@ class Blink:
             filename = os.path.join(path, filename)
 
             if not debug:
-                if await ospath.isfile(filename):
+                if await aiofiles.ospath.isfile(filename):
                     _LOGGER.info("%s already exists, skipping...", filename)
                     continue
 
                 response = await self.do_http_get(address)
-                async with open(filename, "wb") as vidfile:
+                async with aiofiles.open(filename, "wb") as vidfile:
                     await vidfile.write(await response.read())
 
                 _LOGGER.info("Downloaded video to %s", filename)

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -16,8 +16,7 @@ import os.path
 import time
 import logging
 import datetime
-import aiofiles
-from aiofiles import ospath
+from aiofiles import ospath, open
 
 from requests.structures import CaseInsensitiveDict
 from dateutil.parser import parse
@@ -419,7 +418,7 @@ class Blink:
                     continue
 
                 response = await self.do_http_get(address)
-                async with aiofiles.open(filename, "wb") as vidfile:
+                async with open(filename, "wb") as vidfile:
                     await vidfile.write(await response.read())
 
                 _LOGGER.info("Downloaded video to %s", filename)

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -6,11 +6,11 @@ import logging
 import time
 import secrets
 import re
-from aiofiles import open
 from asyncio import sleep
 from calendar import timegm
 from functools import wraps
 from getpass import getpass
+import aiofiles
 import dateutil.parser
 from blinkpy.helpers import constants as const
 
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 async def json_load(file_name):
     """Load json credentials from file."""
     try:
-        async with open(file_name, "r") as json_file:
+        async with aiofiles.open(file_name, "r") as json_file:
             test = await json_file.read()
             data = json.loads(test)
         return data
@@ -34,7 +34,7 @@ async def json_load(file_name):
 
 async def json_save(data, file_name):
     """Save data to file location."""
-    async with open(file_name, "w") as json_file:
+    async with aiofiles.open(file_name, "w") as json_file:
         await json_file.write(json.dumps(data, indent=4))
 
 

--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -6,7 +6,7 @@ import logging
 import time
 import secrets
 import re
-import aiofiles
+from aiofiles import open
 from asyncio import sleep
 from calendar import timegm
 from functools import wraps
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 async def json_load(file_name):
     """Load json credentials from file."""
     try:
-        async with aiofiles.open(file_name, "r") as json_file:
+        async with open(file_name, "r") as json_file:
             test = await json_file.read()
             data = json.loads(test)
         return data
@@ -34,7 +34,7 @@ async def json_load(file_name):
 
 async def json_save(data, file_name):
     """Save data to file location."""
-    async with aiofiles.open(file_name, "w") as json_file:
+    async with open(file_name, "w") as json_file:
         await json_file.write(json.dumps(data, indent=4))
 
 

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -4,7 +4,7 @@ import string
 import datetime
 import traceback
 import asyncio
-import aiofiles
+from aiofiles import open
 from sortedcontainers import SortedSet
 from requests.structures import CaseInsensitiveDict
 from blinkpy import api
@@ -732,7 +732,7 @@ class LocalStorageMediaItem:
             url = blink.urls.base_url + self.url()
             video = await api.http_get(blink, url, json=False)
             if video.status == 200:
-                async with aiofiles.open(file_name, "wb") as vidfile:
+                async with open(file_name, "wb") as vidfile:
                     await vidfile.write(await video.read())  # download the video
                     return True
             seconds = backoff_seconds(retry=retry, default_time=3)

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -4,7 +4,7 @@ import string
 import datetime
 import traceback
 import asyncio
-from aiofiles import open
+import aiofiles
 from sortedcontainers import SortedSet
 from requests.structures import CaseInsensitiveDict
 from blinkpy import api
@@ -732,7 +732,7 @@ class LocalStorageMediaItem:
             url = blink.urls.base_url + self.url()
             video = await api.http_get(blink, url, json=False)
             if video.status == 200:
-                async with open(file_name, "wb") as vidfile:
+                async with aiofiles.open(file_name, "wb") as vidfile:
                     await vidfile.write(await video.read())  # download the video
                     return True
             seconds = backoff_seconds(retry=retry, default_time=3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ include-package-data = true
 include = ["blinkpy*"]
 
 [tool.ruff]
-select = [
+lint.select = [
     "C",  # complexity
     "D",  # docstrings
     "E",  # pydocstyle
@@ -54,11 +54,11 @@ select = [
     "Q000",  # Double quotes found but single quotes preferred
     "SIM118",  # Use {key} in {dict} instead of {key} in {dict}.keys()
     "TRY004",  # Prefer TypeError exception for invalid type
-    "TRY200",  # Use raise from to specify exception cause
+    "B904",  # Use raise from to specify exception cause
     "UP",  # pyupgrade
     "W",  # pycodestyle
 ]
-ignore = [
+lint.ignore = [
     "D202",  # No blank lines allowed after function docstring
     "D203",  # 1 blank line required before class docstring
     "D212",  # Multi-line docstring summary should start at the first line
@@ -86,10 +86,9 @@ ignore = [
 
 line-length = 88
 
-target-version = "py311"
+target-version = "py312"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 
-
-[tool.ruff.mccabe]
-max-complexity = 25
+[tool.ruff.lint.mccabe]
+    max-complexity = 25


### PR DESCRIPTION
## Description:
Reviewing https://github.com/home-assistant/core/issues/108833 I noticed a bit of double importing.  This should not change the behavior just tidy things up.

Additionally, received a few warnings from ruff/lint in the pyporject.toml files.  Implemented the recommended changes

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
