### PR TITLE
Reformat to enable black 24.3.0

### DIFF
--- a/blinkapp/blinkapp.py
+++ b/blinkapp/blinkapp.py
@@ -1,4 +1,5 @@
 """Script to run blinkpy as an blinkapp."""
+
 from os import environ
 import asyncio
 from datetime import datetime, timedelta

--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -1,4 +1,5 @@
 """Login handler for blink."""
+
 import logging
 from aiohttp import (
     ClientSession,

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -1,4 +1,5 @@
 """Defines Blink cameras."""
+
 import copy
 import string
 import os

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -1,4 +1,5 @@
 """Defines a sync module for Blink."""
+
 import logging
 import string
 import datetime

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 ruff==0.3.7
-black==23.12.1
+black==24.3.0
 build==1.2.1
 coverage==7.4.0
 pytest==8.1.1

--- a/tests/mock_responses.py
+++ b/tests/mock_responses.py
@@ -1,4 +1,5 @@
 """Simple mock responses definitions."""
+
 from unittest import mock
 
 

--- a/tests/test_blink_functions.py
+++ b/tests/test_blink_functions.py
@@ -1,4 +1,5 @@
 """Tests camera and system functions."""
+
 from unittest import mock, IsolatedAsyncioTestCase
 import time
 import random

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -69,9 +69,12 @@ class TestBlinkSetup(IsolatedAsyncioTestCase):
         self.assertEqual(self.blink.last_refresh, None)
         self.assertEqual(self.blink.check_if_ok_to_update(), True)
         self.assertEqual(self.blink.last_refresh, None)
-        with mock.patch(
-            "blinkpy.sync_module.BlinkSyncModule.refresh", return_value=True
-        ), mock.patch("blinkpy.blinkpy.Blink.get_homescreen", return_value=True):
+        with (
+            mock.patch(
+                "blinkpy.sync_module.BlinkSyncModule.refresh", return_value=True
+            ),
+            mock.patch("blinkpy.blinkpy.Blink.get_homescreen", return_value=True),
+        ):
             await self.blink.refresh(force=True)
 
         self.assertEqual(self.blink.last_refresh, now)
@@ -81,12 +84,12 @@ class TestBlinkSetup(IsolatedAsyncioTestCase):
     async def test_not_available_refresh(self):
         """Check that setup_post_verify executes on refresh when not avialable."""
         self.blink.available = False
-        with mock.patch(
-            "blinkpy.sync_module.BlinkSyncModule.refresh", return_value=True
-        ), mock.patch(
-            "blinkpy.blinkpy.Blink.get_homescreen", return_value=True
-        ), mock.patch(
-            "blinkpy.blinkpy.Blink.setup_post_verify", return_value=True
+        with (
+            mock.patch(
+                "blinkpy.sync_module.BlinkSyncModule.refresh", return_value=True
+            ),
+            mock.patch("blinkpy.blinkpy.Blink.get_homescreen", return_value=True),
+            mock.patch("blinkpy.blinkpy.Blink.setup_post_verify", return_value=True),
         ):
             self.assertTrue(await self.blink.refresh(force=True))
             with mock.patch("time.time", return_value=time.time() + 4):

--- a/tests/test_doorbell_as_sync.py
+++ b/tests/test_doorbell_as_sync.py
@@ -1,4 +1,5 @@
 """Tests camera and system functions."""
+
 from unittest import mock
 from unittest import IsolatedAsyncioTestCase
 import pytest

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,5 @@
 """Test blink Utils errors."""
+
 import unittest
 from blinkpy.helpers.errors import (
     USERNAME,

--- a/tests/test_mini_as_sync.py
+++ b/tests/test_mini_as_sync.py
@@ -1,4 +1,5 @@
 """Tests camera and system functions."""
+
 from unittest import mock
 from unittest import IsolatedAsyncioTestCase
 import pytest

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -1,4 +1,5 @@
 """Tests camera and system functions."""
+
 import datetime
 import logging
 from unittest import IsolatedAsyncioTestCase
@@ -31,7 +32,7 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         self.blink: Blink = Blink(motion_interval=0, session=mock.AsyncMock())
         self.blink.last_refresh = 0
         self.blink.urls = BlinkURLHandler("test")
-        self.blink.sync["test"]: (BlinkSyncModule) = BlinkSyncModule(
+        self.blink.sync["test"]: BlinkSyncModule = BlinkSyncModule(
             self.blink, "test", "1234", []
         )
         self.blink.sync["test"].network_info = {"network": {"armed": True}}


### PR DESCRIPTION
## Description:
Reformat files allowing blink 24.3.0 to be enabled.

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
