### PR TITLE
Pin issues

### DIFF
--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -132,6 +132,7 @@ class Auth:
         self.token = self.login_response["auth"]["token"]
         self.client_id = self.login_response["account"]["client_id"]
         self.account_id = self.login_response["account"]["account_id"]
+        self.user_id = self.login_response["account"]["user_id"]
 
     async def startup(self):
         """Initialize tokens for communication."""

--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -132,7 +132,7 @@ class Auth:
         self.token = self.login_response["auth"]["token"]
         self.client_id = self.login_response["account"]["client_id"]
         self.account_id = self.login_response["account"]["account_id"]
-        self.user_id = self.login_response["account"]["user_id"]
+        self.user_id = self.login_response["account"].get("user_id", None)
 
     async def startup(self):
         """Initialize tokens for communication."""

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -179,6 +179,9 @@ class Blink:
         """Check for mini cameras."""
         network_list = []
         camera_list = []
+        if self.homescreen is None:
+          # Don't try to iterate if homescreen is not defined
+          return camera_list
         try:
             for owl in self.homescreen["owls"]:
                 name = owl["name"]
@@ -203,6 +206,9 @@ class Blink:
         """Check for doorbells cameras."""
         network_list = []
         camera_list = []
+        if self.homescreen is None:
+          # Don't try to iterate if homescreen is not defined
+          return camera_list
         try:
             for lotus in self.homescreen["doorbells"]:
                 name = lotus["name"]

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -180,8 +180,8 @@ class Blink:
         network_list = []
         camera_list = []
         if self.homescreen is None:
-          # Don't try to iterate if homescreen is not defined
-          return camera_list
+            # Don't try to iterate if homescreen is not defined
+            return camera_list
         try:
             for owl in self.homescreen["owls"]:
                 name = owl["name"]
@@ -207,8 +207,8 @@ class Blink:
         network_list = []
         camera_list = []
         if self.homescreen is None:
-          # Don't try to iterate if homescreen is not defined
-          return camera_list
+            # Don't try to iterate if homescreen is not defined
+            return camera_list
         try:
             for lotus in self.homescreen["doorbells"]:
                 name = lotus["name"]

--- a/blinkpy/blinkpy.py
+++ b/blinkpy/blinkpy.py
@@ -179,9 +179,6 @@ class Blink:
         """Check for mini cameras."""
         network_list = []
         camera_list = []
-        if self.homescreen is None:
-            # Don't try to iterate if homescreen is not defined
-            return camera_list
         try:
             for owl in self.homescreen["owls"]:
                 name = owl["name"]
@@ -195,7 +192,7 @@ class Blink:
                     network_list.append(str(network_id))
                     self.sync[name] = BlinkOwl(self, name, network_id, owl)
                     await self.sync[name].start()
-        except KeyError:
+        except (KeyError, TypeError):
             # No sync-less devices found
             pass
 
@@ -206,9 +203,6 @@ class Blink:
         """Check for doorbells cameras."""
         network_list = []
         camera_list = []
-        if self.homescreen is None:
-            # Don't try to iterate if homescreen is not defined
-            return camera_list
         try:
             for lotus in self.homescreen["doorbells"]:
                 name = lotus["name"]
@@ -228,7 +222,7 @@ class Blink:
                     network_list.append(str(network_id))
                     self.sync[name] = BlinkLotus(self, name, network_id, lotus)
                     await self.sync[name].start()
-        except KeyError:
+        except (KeyError, TypeError):
             # No sync-less devices found
             pass
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -167,6 +167,7 @@ class TestAuth(IsolatedAsyncioTestCase):
         self.assertEqual(self.auth.token, "foobar")
         self.assertEqual(self.auth.client_id, 1234)
         self.assertEqual(self.auth.account_id, 5678)
+        self.assertEqual(self.auth.user_id, None)
 
         mock_resp.return_value.status = 400
         with self.assertRaises(TokenRefreshFailed):


### PR DESCRIPTION
## Description:
Implementing fixes discussed in #917 log.  
1. populate self.user_id from login_data of response to avoid the below errors after entering PIN:
```
Did not receive valid response from server. Error: 'valid'
Unable to access https://rest-u056.immedia-semi.com/networks after token refresh.
```
2. Check for homescreen is None before trying to populate owls and lotus from it, to avoid `Unable to retrieve cameras from response` error after entering PIN on initial auth.

I have tested that these changes work with a flow similar to that in blinkapp:
* On initial auth with no credfile and entering username/password/pin
* On subsequent run with saved credfile from first run (without prompting for pin)

They don't currently pass the tox tests and i think it is because i'm referencing the user_id of the login_data response and that isn't in the mock test response.   I'm happy to work on getting the tox tests to pass but would appreciate pointers from someone who is more familiar with the test framework.

**Related issue (if applicable):** fixes #917 

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [X] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
