### PR TITLE
Fix clip recording for Blink Mini and Doorbell camera models

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -516,6 +516,17 @@ class BlinkCameraMini(BlinkCamera):
         await api.wait_for_command(self.sync.blink, response)
         return response
 
+    async def record(self):
+        """Initiate clip recording for a blink mini camera."""
+        url = (
+            f"{self.sync.urls.base_url}/api/v1/accounts/"
+            f"{self.sync.blink.account_id}/networks/"
+            f"{self.network_id}/owls/{self.camera_id}/clip"
+        )
+        response = await api.http_post(self.sync.blink, url)
+        await api.wait_for_command(self.sync.blink, response)
+        return response
+
     async def snap_picture(self):
         """Snap picture for a blink mini camera."""
         url = (
@@ -570,6 +581,18 @@ class BlinkDoorbell(BlinkCamera):
             url = f"{url}/enable"
         else:
             url = f"{url}/disable"
+
+        response = await api.http_post(self.sync.blink, url)
+        await api.wait_for_command(self.sync.blink, response)
+        return response
+
+    async def record(self):
+        """Initiate clip recording for a blink doorbell camera."""
+        url = (
+            f"{self.sync.urls.base_url}/api/v1/accounts/"
+            f"{self.sync.blink.account_id}/networks/"
+            f"{self.sync.network_id}/doorbells/{self.camera_id}/clip"
+        )
 
         response = await api.http_post(self.sync.blink, url)
         await api.wait_for_command(self.sync.blink, response)


### PR DESCRIPTION
## Description:
Add missing camera model specific API service URLs.

See: https://community.home-assistant.io/t/start-recording-blink-camera-based-on-motion-or-ringing-of-my-ring-doorbell/382208/15?u=mback2k

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
