### PR TITLE
Fix tests with aiohttp >= 3.10.0

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,7 @@ COMMAND_NOT_COMPLETE = {"complete": False, "status_code": 908}
 class TestAPI(IsolatedAsyncioTestCase):
     """Test the API class in blinkpy."""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         """Set up Login Handler."""
         self.blink = Blink(session=mock.AsyncMock())
         self.auth = Auth()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,7 +19,7 @@ PASSWORD = "deadbeef"
 class TestAuth(IsolatedAsyncioTestCase):
     """Test the Auth class in blinkpy."""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         """Set up Login Handler."""
         self.auth = Auth()
 
@@ -29,7 +29,7 @@ class TestAuth(IsolatedAsyncioTestCase):
 
     @mock.patch("blinkpy.helpers.util.gen_uid")
     @mock.patch("blinkpy.auth.util.getpass")
-    def test_empty_init(self, getpwd, genuid):
+    async def test_empty_init(self, getpwd, genuid):
         """Test initialization with no params."""
         auth = Auth()
         self.assertDictEqual(auth.data, {})
@@ -47,7 +47,7 @@ class TestAuth(IsolatedAsyncioTestCase):
 
     @mock.patch("blinkpy.helpers.util.gen_uid")
     @mock.patch("blinkpy.auth.util.getpass")
-    def test_barebones_init(self, getpwd, genuid):
+    async def test_barebones_init(self, getpwd, genuid):
         """Test basebones initialization."""
         login_data = {"username": "foo", "password": "bar"}
         auth = Auth(login_data)
@@ -64,7 +64,7 @@ class TestAuth(IsolatedAsyncioTestCase):
         }
         self.assertDictEqual(auth.data, expected_data)
 
-    def test_full_init(self):
+    async def test_full_init(self):
         """Test full initialization."""
         login_data = {
             "username": "foo",

--- a/tests/test_blinkpy.py
+++ b/tests/test_blinkpy.py
@@ -28,7 +28,7 @@ class TestBlinkSetup(IsolatedAsyncioTestCase):
         """Cleanup blink test object."""
         self.blink = None
 
-    def test_initialization(self):
+    async def test_initialization(self):
         """Verify we can initialize blink."""
         blink = Blink()
         self.assertEqual(blink.version, __version__)


### PR DESCRIPTION
## Description:

aiohttp 3.10.0 removed the ability to create `aiohttp.ClientSession` instances without a running event loop (see
https://github.com/aio-libs/aiohttp/pull/8583), but a few of blinkpy's tests relied on that.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be merged unless tests pass**
- [ ] Changes tested locally to ensure platform still works as intended (not done because I don't actually use this package, but this is a test-only change)
- [x] Tests added to verify new code works
