### PR TITLE
Add Per Camera Snooze Functionality

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -491,6 +491,42 @@ async def request_update_config(
         return None
     return await http_post(blink, url, json=False, data=data)
 
+async def request_camera_snooze(
+        blink, network, camera_id, product_type="owl", data=None
+    ):
+        """
+        Update camera snooze configuration.
+
+        :param blink: Blink instance.
+        :param network: Sync module network id.
+        :param camera_id: ID of camera
+        :param product_type: Camera product type "owl" or "catalina"
+        :param data: string w/JSON dict of parameters/values to update
+        """
+        if product_type == "catalina":
+            url = (
+                f"{blink.urls.base_url}/api/v1/accounts/{blink.account_id}/"
+                f"networks/{network}/cameras/{camera_id}/snooze"
+            )
+        elif product_type == "owl":
+            url = (
+                f"{blink.urls.base_url}/api/v1/accounts/{blink.account_id}/"
+                f"networks/{network}/owls/{camera_id}/snooze"
+            )
+        elif product_type == "doorbell":
+            url = (
+                f"{blink.urls.base_url}/api/v1/accounts/{blink.account_id}/"
+                f"networks/{network}/doorbells/{camera_id}/snooze"
+            )
+        else:
+            _LOGGER.info(
+                "Camera %s with product type %s snooze update not implemented.",
+                camera_id,
+                product_type,
+            )
+            return None
+        return await http_post(blink, url, json=False, data=data)
+
 
 async def http_get(
     blink, url, stream=False, json=True, is_retry=False, timeout=TIMEOUT

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -170,6 +170,35 @@ class BlinkCamera:
             return await res.json()
         return None
 
+    @property
+    async def snooze_till(self):
+        """Return snooze_till status."""
+        res = await api.request_get_config(
+            self.sync.blink,
+            self.network_id,
+            self.camera_id,
+            product_type=self.product_type,
+        )
+        if res is None:
+            return None
+        if self.product_type == "catalina":
+            res = res.get("camera", [{}])[0]["snooze_till"]
+        return res
+
+    async def async_snooze(self):
+        """Set camera snooze status."""
+        data = dumps({"snooze_time": 240})
+        res = await api.request_camera_snooze(
+            self.sync.blink,
+            self.network_id,
+            self.camera_id,
+            product_type=self.product_type,
+            data=data,
+        )
+        if res and res.status == 200:
+            return await res.json()
+        return None
+
     async def record(self):
         """Initiate clip recording."""
         return await api.request_new_video(
@@ -625,3 +654,17 @@ class BlinkDoorbell(BlinkCamera):
         server = response["server"]
         link = server.replace("immis://", "rtsps://")
         return link
+
+    async def async_snooze(self):
+        """Set camera snooze status."""
+        data = dumps({"snooze_time": 240})
+        res = await api.request_camera_snooze(
+            self.sync.blink,
+            self.network_id,
+            self.camera_id,
+            product_type="doorbell",
+            data=data,
+        )
+        if res and res.status == 200:
+            return await res.json()
+        return None


### PR DESCRIPTION
## Description:
Implements a per camera snooze function as present here: https://github.com/MattTW/BlinkMonitorProtocol/issues/67

Currently supports:
- Getting the remaining snooze time for the camera in the format of "this time stamp is when snoozing will expire".
- Setting the camera to snooze notifications
  - I was unable to find a value other than "240" minutes (4 hours) that worked. 

There is more than can be implemented, such as snoozing an entire sync module's cameras. 

As far as testing:
- Currently blocked by another PR (https://github.com/fronzbot/blinkpy/pull/974)
- I have tried writing tests for this PR but just not familiar enough with tox/mock testing. Seems like only 3 tests are needed:
  - "snooze_till" property
  - "snooze" function
  - "request_camera_snooze" request

Reason for removing my previous PR: Somehow messed up the git history while trying to squash to a single commit.

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [ ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [X] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
