### PR TITLE
Reduce impact of re-creating patterns dict per API request

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -30,7 +30,9 @@ MAX_RETRY = 120
 # Use "data" for static payloads, "data_template" for dynamic payloads
 _CAMERA_ACTION_PATTERNS = {
     "mini": {
-        "base_template": "/api/v1/accounts/{account_id}/networks/{network}/owls/{camera_id}",
+        "base_template": (
+            "/api/v1/accounts/{account_id}/networks/{network}/owls/{camera_id}"
+        ),
         "actions": {
             "arm": {
                 "path": "config",
@@ -45,7 +47,9 @@ _CAMERA_ACTION_PATTERNS = {
         },
     },
     "doorbell": {
-        "base_template": "/api/v1/accounts/{account_id}/networks/{network}/doorbells/{camera_id}",
+        "base_template": (
+            "/api/v1/accounts/{account_id}/networks/{network}/doorbells/{camera_id}"
+        ),
         "actions": {
             "arm": {
                 "path_template": "{arm_action}",  # "enable" or "disable"
@@ -67,7 +71,10 @@ _CAMERA_ACTION_PATTERNS = {
             "record": {"path": "clip"},
             "snap": {"path": "thumbnail"},
             "liveview": {
-                "path": "/api/v5/accounts/{account_id}/networks/{network}/cameras/{camera_id}/liveview",
+                "path": (
+                    "/api/v5/accounts/{account_id}"
+                    "/networks/{network}/cameras/{camera_id}/liveview"
+                ),
                 "data": {"intent": "liveview"},  # static payload
                 "full_path": True,
             },


### PR DESCRIPTION
## Description:
Reduce impact of re-creating `patterns` dict per API request
by using global dict as template which is only slightly modified.
And add missing return statements to `wait_for_command`.

**Related issue (if applicable):** fixes #<blinkpy issue number goes here>

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works
