### PR TITLE
Fix for camera arm/disarm including proper unittests for this function

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -698,13 +698,7 @@ async def request_camera_action(
     data = None
     if "data_template" in action_config:
         # Dynamic payload with runtime value substitution
-        data_dict = {}
-        for key, value in action_config["data_template"].items():
-            if callable(value):
-                data_dict[key] = value(kwargs)
-            else:
-                data_dict[key] = value
-        data = dumps(data_dict)
+        data = dumps(action_config["data_template"](kwargs))
     elif "data" in action_config:
         # Static payload
         data = dumps(action_config["data"])

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -6,14 +6,18 @@ individual BlinkCamera instantiations once the
 Blink system is set up.
 """
 
+import importlib
 from unittest import mock
 from unittest import IsolatedAsyncioTestCase
 import pytest
+
+import blinkpy.api
 from blinkpy.blinkpy import Blink
-from blinkpy.helpers.util import BlinkURLHandler
 from blinkpy.sync_module import BlinkSyncModule
 from blinkpy.camera import BlinkCamera, BlinkCameraMini, BlinkDoorbell
 from blinkpy.livestream import BlinkLiveStream
+from blinkpy.helpers import util
+
 import tests.mock_responses as mresp
 
 CONFIG = {
@@ -30,62 +34,73 @@ CONFIG = {
 }
 
 
+def mock_throttle(*args, **kwargs):
+    """Mock class for Throttle decorator."""
+
+    def decorator(func):
+        return func
+
+    return decorator
+
+
 @mock.patch("blinkpy.auth.Auth.query", return_value={})
 class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
     """Test the Blink class in blinkpy."""
 
     def setUp(self):
         """Set up Blink module."""
+        self.throttle_patch = mock.patch("blinkpy.api.Throttle", mock_throttle)
+        self.throttle_patch.start()
+
+        importlib.reload(blinkpy.api)
+
         self.blink = Blink(session=mock.AsyncMock())
-        self.blink.urls = BlinkURLHandler("test")
+        self.blink.urls = util.BlinkURLHandler("test")
         self.blink.sync["test"] = BlinkSyncModule(self.blink, "test", 1234, [])
         self.camera = BlinkCamera(self.blink.sync["test"])
         self.camera.name = "foobar"
+        self.mini_camera = BlinkCameraMini(self.blink.sync["test"])
+        self.doorbell = BlinkDoorbell(self.blink.sync["test"])
+
         self.blink.sync["test"].cameras["foobar"] = self.camera
 
     def tearDown(self):
         """Clean up after test."""
         self.blink = None
         self.camera = None
+        self.mini_camera = None
+        self.doorbell = None
+        self.throttle_patch.stop()
 
-    @mock.patch(
-        "blinkpy.api.request_motion_detection_enable",
-        mock.AsyncMock(return_value="enable"),
-    )
-    @mock.patch(
-        "blinkpy.api.request_motion_detection_disable",
-        mock.AsyncMock(return_value="disable"),
-    )
-    async def test_camera_arm_status(self, mock_resp):
-        """Test arming and disarming camera."""
-        self.camera.motion_enabled = None
-        await self.camera.async_arm(None)
-        self.assertFalse(self.camera.arm)
-        await self.camera.async_arm(False)
-        self.camera.motion_enabled = False
-        self.assertFalse(self.camera.arm)
-        await self.camera.async_arm(True)
-        self.camera.motion_enabled = True
-        self.assertTrue(self.camera.arm)
+    async def test_camera_arm_disarm(self, mock_resp):
+        """Test base camera arm and disarm."""
+        with mock.patch(
+            "blinkpy.api.wait_for_command", new_callable=mock.AsyncMock
+        ) as mock_wait:
+            mock_resp.side_effect = ["arm", "disarm"]
+            mock_wait.side_effect = [True, True]
+            self.assertEqual(await self.camera.async_arm(True), "arm")
+            self.assertEqual(await self.camera.async_arm(False), "disarm")
 
-        self.camera = BlinkCameraMini(self.blink.sync["test"])
-        self.camera.motion_enabled = None
-        await self.camera.async_arm(None)
-        self.assertFalse(self.camera.arm)
+    async def test_mini_camera_arm_disarm(self, mock_resp):
+        """Test mini camera arm and disarm."""
+        with mock.patch(
+            "blinkpy.api.wait_for_command", new_callable=mock.AsyncMock
+        ) as mock_wait:
+            mock_resp.side_effect = ["arm", "disarm"]
+            mock_wait.return_value = [True, True]
+            self.assertEqual(await self.mini_camera.async_arm(True), "arm")
+            self.assertEqual(await self.mini_camera.async_arm(False), "disarm")
 
-    async def test_doorbell_camera_arm(self, mock_resp):
-        """Test arming and disarming camera."""
-        self.blink.sync.arm = False
-        doorbell_camera = BlinkDoorbell(self.blink.sync["test"])
-        doorbell_camera.motion_enabled = None
-        await doorbell_camera.async_arm(None)
-        self.assertFalse(doorbell_camera.arm)
-        await doorbell_camera.async_arm(False)
-        doorbell_camera.motion_enabled = False
-        self.assertFalse(doorbell_camera.arm)
-        await doorbell_camera.async_arm(True)
-        doorbell_camera.motion_enabled = True
-        self.assertTrue(doorbell_camera.arm)
+    async def test_doorbell_arm_disarm(self, mock_resp):
+        """Test doorbell arm and disarm."""
+        with mock.patch(
+            "blinkpy.api.wait_for_command", new_callable=mock.AsyncMock
+        ) as mock_wait:
+            mock_resp.side_effect = ["arm", "disarm"]
+            mock_wait.side_effect = [True, True]
+            self.assertEqual(await self.doorbell.async_arm(True), "arm")
+            self.assertEqual(await self.doorbell.async_arm(False), "disarm")
 
     def test_missing_attributes(self, mock_resp):
         """Test that attributes return None if missing."""
@@ -101,10 +116,10 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     def test_mini_missing_attributes(self, mock_resp):
         """Test that attributes return None if missing."""
-        camera = BlinkCameraMini(self.blink.sync)
+        self.mini_camera = BlinkCameraMini(self.blink.sync)
         self.blink.sync.network_id = None
         self.blink.sync.name = None
-        attr = camera.attributes
+        attr = self.mini_camera.attributes
         for key in attr:
             if key == "recent_clips":
                 self.assertEqual(attr[key], [])
@@ -113,10 +128,10 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     def test_doorbell_missing_attributes(self, mock_resp):
         """Test that attributes return None if missing."""
-        camera = BlinkDoorbell(self.blink.sync)
+        self.doorbell = BlinkDoorbell(self.blink.sync)
         self.blink.sync.network_id = None
         self.blink.sync.name = None
-        attr = camera.attributes
+        attr = self.doorbell.attributes
         for key in attr:
             if key == "recent_clips":
                 self.assertEqual(attr[key], [])
@@ -126,17 +141,15 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
     async def test_camera_stream(self, mock_resp):
         """Test that camera stream returns correct url."""
         mock_resp.return_value = {"server": "rtsps://foo.bar"}
-        mini_camera = BlinkCameraMini(self.blink.sync["test"])
-        doorbell_camera = BlinkDoorbell(self.blink.sync["test"])
         self.assertEqual(await self.camera.get_liveview(), "rtsps://foo.bar")
-        self.assertEqual(await mini_camera.get_liveview(), "rtsps://foo.bar")
-        self.assertEqual(await doorbell_camera.get_liveview(), "rtsps://foo.bar")
+        self.assertEqual(await self.mini_camera.get_liveview(), "rtsps://foo.bar")
+        self.assertEqual(await self.doorbell.get_liveview(), "rtsps://foo.bar")
         with pytest.raises(NotImplementedError):
             await self.camera.init_livestream()
         with pytest.raises(NotImplementedError):
-            await mini_camera.init_livestream()
+            await self.mini_camera.init_livestream()
         with pytest.raises(NotImplementedError):
-            await doorbell_camera.init_livestream()
+            await self.doorbell.init_livestream()
 
     async def test_camera_livestream(self, mock_resp):
         """Test that camera livestream returns correct object."""
@@ -156,11 +169,9 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             "options": {"poor_connection": False},
             "liveview_token": "abcdefghijklmnopqrstuv",
         }
-        mini_camera = BlinkCameraMini(self.blink.sync["test"])
-        doorbell_camera = BlinkDoorbell(self.blink.sync["test"])
         self.assertIsInstance(await self.camera.init_livestream(), BlinkLiveStream)
-        self.assertIsInstance(await mini_camera.init_livestream(), BlinkLiveStream)
-        self.assertIsInstance(await doorbell_camera.init_livestream(), BlinkLiveStream)
+        self.assertIsInstance(await self.mini_camera.init_livestream(), BlinkLiveStream)
+        self.assertIsInstance(await self.doorbell.init_livestream(), BlinkLiveStream)
 
     async def test_different_thumb_api(self, mock_resp):
         """Test that the correct url is created with new api."""


### PR DESCRIPTION
## Description:
For mini and doorbell cameras, the request action function uses a lambda for dynamic population. However, that lambda was trying to access `items()` as if it was a function. Instead, we properly handle that lambda to create the necessary dictionary which should fix the bug.

**Related issue (if applicable):** fixes #1153 

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ ] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
