### PR TITLE
Enhance 2FA handling in OAuth flow

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -847,8 +847,15 @@ async def oauth_signin(auth, email, password, csrf_token):
         OAUTH_SIGNIN_URL, headers=headers, data=data, allow_redirects=False
     )
 
-    if response.status == 412:
-        # 2FA required
+    if response.status in [412, 202]:
+        # 2FA required:
+        #   412 = standard Blink response
+        #   202 = alternate response observed on some accounts (same semantics: SMS/PIN sent)
+        auth._manual_cookie_store = {
+            cookie.key: cookie.value
+            for cookie in auth.session.cookie_jar
+        }
+        _LOGGER.debug("Blink: captured %d cookies for 2FA (status=%s)", len(auth._manual_cookie_store), response.status)
         return "2FA_REQUIRED"
     elif response.status in [301, 302, 303, 307, 308]:
         # Success without 2FA
@@ -884,7 +891,16 @@ async def oauth_verify_2fa(auth, csrf_token, twofa_code):
         "remember_me": "false",
     }
 
-    response = await auth.session.post(OAUTH_2FA_VERIFY_URL, headers=headers, data=data)
+    # Restore cookies that may be lost between oauth_signin and 2FA verification
+    if hasattr(auth, '_manual_cookie_store') and auth._manual_cookie_store:
+        auth.session.cookie_jar.update_cookies(auth._manual_cookie_store)
+        auth.session.cookie_jar._unsafe = True
+        _LOGGER.debug("Blink: restored %d cookies for 2FA verification", len(auth._manual_cookie_store))
+
+    response = await auth.session.post(
+        OAUTH_2FA_VERIFY_URL, headers=headers, data=data,
+        cookies=auth._manual_cookie_store if hasattr(auth, '_manual_cookie_store') else None
+    )
 
     if response.status == 201:
         try:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -101,6 +101,7 @@ async def test_oauth_signin_2fa_required():
     """Test OAuth signin when 2FA is required."""
     auth = Mock()
     auth.session = Mock()
+    auth.session.cookie_jar = []  # iterable, no cookies to capture
 
     response = Mock()
     response.status = 412  # 2FA required
@@ -116,6 +117,7 @@ async def test_oauth_verify_2fa():
     """Test 2FA verification."""
     auth = Mock()
     auth.session = Mock()
+    auth._manual_cookie_store = {}  # empty dict: falsy, skips cookie restore block
 
     response = Mock()
     response.status = 201  # Changed from 200 to 201 to match actual API behavior


### PR DESCRIPTION
Handle alternate 2FA response status and restore cookies for verification.

## Description:


**Related issue :** fixes #1217

## Checklist:
- [ x ] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [ x ] Changes tested locally to ensure platform still works as intended
- [ ] Tests added to verify new code works

# PR description — fronzbot/blinkpy

**Title:** `fix: handle HTTP 202 response in oauth_signin and restore cookies for 2FA verification`

---

## Summary

Two fixes to the OAuth 2FA flow, identified and confirmed by tracing the full OAuth sequence in a live Home Assistant environment (June 2026).

## Changes

### 1. `blinkpy/api.py` — `oauth_signin`: handle HTTP 202 as 2FA required

Blink's OAuth endpoint now returns **HTTP 202** (in addition to, or instead of, 412) to signal that 2FA is required and a PIN has been sent. The function previously only handled 412 and returned `None` for any other status, causing the login flow to silently fail.

This fix treats 202 and 412 identically, and captures the current cookie jar for reuse in the verification step.

### 2. `blinkpy/api.py` — `oauth_verify_2fa`: restore cookies before verification POST

In some `aiohttp` configurations (notably when using HA's shared session), cookies accumulated during `oauth_signin` are not preserved across requests. This fix explicitly restores the captured cookie jar before the verification POST, and passes them as request cookies as well.

## Observed behaviour before fix

```
oauth_signin: status=202 cookies=5
→ returned None (unhandled status)
→ _oauth_login_flow fails
→ BlinkTwoFARequiredError never raised
→ HA never shows PIN input form
→ SMS received by user but no way to complete auth
```

## Observed behaviour after fix

```
oauth_signin: status=202 → 2FA_REQUIRED returned
→ HA displays PIN input form
→ user enters PIN
→ oauth_verify_2fa succeeds
→ integration active
```

## Testing

Tested on:
- Home Assistant 2026.5.0 (Docker)
- Blink account with mandatory SMS 2FA (cannot be disabled as of June 2026)
- Account previously linked to Amazon, then unlinked

## Related

- Fixes #1217
- Related HA core PR: https://github.com/home-assistant/core/pull/173172

