### PR TITLE
Fix OAuth cookie persistence and HTTP 202 for 2FA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Pipfile.lock
 blink.json
 blinktest.py
 .vscode/*
+.venv/

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -847,13 +847,18 @@ async def oauth_signin(auth, email, password, csrf_token):
         OAUTH_SIGNIN_URL, headers=headers, data=data, allow_redirects=False
     )
 
-    if response.status == 412:
-        # 2FA required
+    if response.status in [412, 202]:
+        # 2FA required (some regions return 202 instead of 412)
         return "2FA_REQUIRED"
     elif response.status in [301, 302, 303, 307, 308]:
         # Success without 2FA
         return "SUCCESS"
 
+    _LOGGER.error(
+        "OAuth signin failed with status %d: %s",
+        response.status,
+        await response.text(),
+    )
     return None
 
 

--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -8,6 +8,7 @@ from aiohttp import (
     ClientConnectionError,
     ContentTypeError,
     ClientResponse,
+    CookieJar,
 )
 from blinkpy import api
 from blinkpy.helpers import util
@@ -64,7 +65,9 @@ class Auth:
         self.no_prompt = no_prompt
         self._agent = agent
         self._app_build = app_build
-        self.session = session if session else ClientSession()
+        self.session = session if session else ClientSession(
+            cookie_jar=CookieJar(unsafe=True),
+        )
 
         # Callback to notify on token refresh
         self.callback = callback

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -2,6 +2,7 @@
 
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
+from aiohttp import CookieJar
 from blinkpy.helpers.pkce import generate_pkce_pair
 from blinkpy import api
 from blinkpy.auth import Auth, BlinkTwoFARequiredError
@@ -98,12 +99,30 @@ async def test_oauth_signin_success():
 
 @pytest.mark.asyncio
 async def test_oauth_signin_2fa_required():
-    """Test OAuth signin when 2FA is required."""
+    """Test OAuth signin when 2FA is required (status 412)."""
     auth = Mock()
     auth.session = Mock()
 
     response = Mock()
     response.status = 412  # 2FA required
+    auth.session.post = AsyncMock(return_value=response)
+
+    result = await api.oauth_signin(auth, "test@example.com", "password", "csrf_token")
+
+    assert result == "2FA_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_oauth_signin_2fa_required_202():
+    """Test OAuth signin when 2FA is required (status 202).
+
+    Some Blink regions return HTTP 202 instead of 412 to indicate 2FA is needed.
+    """
+    auth = Mock()
+    auth.session = Mock()
+
+    response = Mock()
+    response.status = 202  # 2FA required (alternate status)
     auth.session.post = AsyncMock(return_value=response)
 
     result = await api.oauth_signin(auth, "test@example.com", "password", "csrf_token")
@@ -193,6 +212,23 @@ async def test_oauth_refresh_token():
 
     assert result == token_response
     assert result["access_token"] == "new_access_token"
+
+
+@pytest.mark.asyncio
+async def test_auth_uses_unsafe_cookie_jar():
+    """Test that Auth creates session with unsafe CookieJar for OAuth cookie persistence.
+
+    The OAuth flow requires cookies to persist across redirects between
+    different subdomains (e.g., api.oauth.blink.com → rest-a001.immedia-semi.com).
+    aiohttp's default CookieJar drops cookies on cross-domain redirects,
+    which causes the 'empty_cookies' error during the 2FA step.
+    """
+    auth = Auth({"username": "test@example.com", "password": "password"})
+
+    # Verify the session uses an unsafe cookie jar
+    assert isinstance(auth.session.cookie_jar, CookieJar)
+    # The unsafe flag allows cookies to be set/sent across domains
+    assert auth.session.cookie_jar._unsafe is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes two bugs that prevent Blink OAuth v2 login with 2FA from working.

## Bug 1: Cookie persistence (root cause of `empty_cookies` error)

The OAuth v2 flow requires cookies to persist across multiple HTTP requests to `api.oauth.blink.com` (authorize → signin page → submit credentials → 2FA verify → get auth code). 

`aiohttp`'s default `CookieJar` uses strict cookie domain matching, which drops cookies when the OAuth flow redirects or when cookies need to be sent back to the same domain across requests. This causes the Blink API to return:

```json
{"error":"bad_request","error_cause":"empty_cookies","error_description":"Empty Cookies."}
```

**Fix:** Create the `ClientSession` with `CookieJar(unsafe=True)`, which allows cookies to be properly stored and sent across all requests in the OAuth flow.

## Bug 2: HTTP 202 status not recognized as 2FA-required

The current code only checks for HTTP 412 (Precondition Failed) to detect when 2FA is required. However, some Blink regions/versions return HTTP 202 (Accepted) instead:

```json
{"next_time_in_secs":60,"phone":"+61xxxxxxxx40","tsv_methods":["sms","whatsapp","voice"],"tsv_state":"sms","user_id":188584242}
```

**Fix:** Accept both 412 and 202 as 2FA-required responses in `oauth_signin()`.

## Testing

- All 18 existing OAuth tests pass
- Added `test_oauth_signin_2fa_required_202` to cover the 202 status code case
- Added `test_auth_uses_unsafe_cookie_jar` to verify cookie jar configuration
- Tested end-to-end with real Blink account (Australia region, SMS 2FA)

## Related Issues

- Fixes #1217
- Related: home-assistant/core#168029

## Files Changed

- `blinkpy/auth.py` — Use `CookieJar(unsafe=True)` for session creation
- `blinkpy/api.py` — Accept HTTP 202 as 2FA-required, improve error logging
- `tests/test_oauth.py` — New tests for both fixes