### PR TITLE
livestream: read frames with readexactly to avoid truncation

### DIFF
--- a/blinkpy/livestream.py
+++ b/blinkpy/livestream.py
@@ -181,13 +181,12 @@ class BlinkLiveStream:
             _LOGGER.debug("Starting copy from target to clients")
             while not self.target_reader.at_eof():
                 # Read header from the target server
-                data = await self.target_reader.read(9)
-
-                # Check if we have enough data for the header
-                if len(data) < 9:
+                try:
+                    data = await self.target_reader.readexactly(9)
+                except asyncio.IncompleteReadError as err:
                     _LOGGER.warning(
                         "Insufficient data for header: %d bytes, expected 9",
-                        len(data),
+                        len(err.partial),
                     )
                     break
 
@@ -208,13 +207,12 @@ class BlinkLiveStream:
                     continue
 
                 # Read payload from the target server
-                data = await self.target_reader.read(payload_length)
-
-                # Check if we have enough data for the payload
-                if len(data) < payload_length:
+                try:
+                    data = await self.target_reader.readexactly(payload_length)
+                except asyncio.IncompleteReadError as err:
                     _LOGGER.warning(
                         "Insufficient data for payload: %d bytes, expected %d",
-                        len(data),
+                        len(err.partial),
                         payload_length,
                     )
                     break

--- a/tests/test_livestream.py
+++ b/tests/test_livestream.py
@@ -1,5 +1,6 @@
 """Tests for BlinkLiveStream class."""
 
+import asyncio
 import ssl
 import urllib.parse
 from unittest import mock
@@ -259,8 +260,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         mock_writer = mock.Mock()
 
         # Mock client reading data then disconnecting
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [b"test_data", b""]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [b"test_data", b""]
         mock_writer.is_closing.return_value = False
 
         # Start the join coroutine
@@ -276,8 +277,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         mock_writer = mock.Mock()
 
         # Mock connection reset error
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = ConnectionResetError()
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = ConnectionResetError()
         mock_writer.is_closing.return_value = False
 
         with mock.patch.object(self.livestream, "stop") as mock_stop:
@@ -294,8 +295,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         mock_writer = mock.Mock()
 
         # Mock general exception (not ConnectionResetError)
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = ValueError("Test join exception")
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = ValueError("Test join exception")
         mock_writer.is_closing.return_value = False
 
         with (
@@ -335,8 +336,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         # Mock payload starting with 0x47 (transport stream packet start)
         payload_data = bytearray([0x47] + [0x00] * 187)  # 188 bytes total
 
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [header_data, payload_data, b""]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [header_data, payload_data, asyncio.IncompleteReadError(b"", 9)]
         mock_reader.at_eof.side_effect = [False, False, True]
         mock_client.is_closing.return_value = False
         mock_client.write = mock.Mock()
@@ -374,8 +375,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
 
         payload_data = bytearray([0x47] + [0x00] * 187)  # 188 bytes total
 
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [header_data_invalid, payload_data, b""]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [header_data_invalid, payload_data, asyncio.IncompleteReadError(b"", 9)]
         mock_reader.at_eof.side_effect = [False, False, True]
 
         self.livestream.target_reader = mock_reader
@@ -393,8 +394,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         mock_client = mock.Mock()
 
         # Simulate reading incomplete header
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [b"short", b""]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [asyncio.IncompleteReadError(b"short", 9)]
         mock_reader.at_eof.side_effect = [False, True]
 
         self.livestream.target_reader = mock_reader
@@ -446,8 +447,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
             ]
         )
 
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [header_data_empty, header_data, b"short", b""]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [header_data_empty, header_data, asyncio.IncompleteReadError(b"short", 188)]
         mock_reader.at_eof.side_effect = [False, False, True]
 
         self.livestream.target_reader = mock_reader
@@ -462,7 +463,7 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
             mock_logger.assert_called_once()
 
         # Verify that the first payload read was skipped (empty payload)
-        self.assertEqual(mock_reader.read.call_count, 3)  # odd number of reads
+        self.assertEqual(mock_reader.readexactly.call_count, 3)  # odd number of reads
 
         # Verify no data was written to client (incomplete header)
         mock_client.write.assert_not_called()
@@ -490,8 +491,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         # Mock payload starting with 0x42 (invalid transport stream packet start)
         payload_data = bytearray([0x42] + [0x00] * 187)  # 188 bytes total
 
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [header_data, payload_data, b""]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [header_data, payload_data, asyncio.IncompleteReadError(b"", 9)]
         mock_reader.at_eof.side_effect = [False, False, True]
         mock_client.is_closing.return_value = False
         mock_client.write = mock.Mock()
@@ -612,8 +613,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         # Mock SSL error
         ssl_error = ssl.SSLError()
         ssl_error.reason = "APPLICATION_DATA_AFTER_CLOSE_NOTIFY"
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = ssl_error
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = ssl_error
         mock_reader.at_eof.return_value = False
 
         self.livestream.target_reader = mock_reader
@@ -634,8 +635,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         # Mock SSL error with different reason
         ssl_error = ssl.SSLError()
         ssl_error.reason = "SOME_OTHER_SSL_ERROR"
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = ssl_error
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = ssl_error
         mock_reader.at_eof.return_value = False
 
         self.livestream.target_reader = mock_reader
@@ -658,8 +659,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         mock_writer = mock.Mock()
 
         # Mock general exception
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = Exception("Test exception")
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = Exception("Test exception")
         mock_reader.at_eof.return_value = False
 
         self.livestream.target_reader = mock_reader
@@ -681,8 +682,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         mock_writer = mock.Mock()
 
         # Mock asyncio timeout exception
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = TimeoutError()
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = TimeoutError()
         mock_reader.at_eof.return_value = False
 
         self.livestream.target_reader = mock_reader


### PR DESCRIPTION
## Description

`BlinkLiveStream.recv()` reads the 9-byte immis frame header and then the
payload with `StreamReader.read(n)`:

```python
data = await self.target_reader.read(9)
if len(data) < 9:
    _LOGGER.warning("Insufficient data for header: %d bytes, expected 9", len(data))
    break
```

`StreamReader.read(n)` returns **up to** `n` bytes — it resolves as soon as *any*
data is buffered. When a header or payload is split across TCP segments (very
common for the larger video payloads), `read()` returns a short buffer, the
`len(data) < n` guard treats it as EOF, and the stream is torn down mid-frame
even though the connection is perfectly healthy.

This replaces both reads with `readexactly()`, which waits for the full frame
and raises `IncompleteReadError` only on a genuine EOF:

```python
try:
    data = await self.target_reader.readexactly(9)
except asyncio.IncompleteReadError:
    _LOGGER.debug("Target closed before a full 9-byte header")
    break
```

### How I found it

While getting live view working through Home Assistant I built a standalone
relay that parses the immis framing from a buffer (accumulate-then-slice) and it
streamed hundreds of H.264 frames reliably. A faithful port that used `read(n)`
instead would intermittently abort with "Insufficient data". The difference is
exactly this partial-read handling.

Note: this is independent of the recent OAuth/2FA (202) and liveview-endpoint
work in #1227/#1228/#1229/#1231 — it's a latent framing bug that surfaces once a
live view actually connects and starts delivering video.

## Checklist
- [x] Behavior verified against a live immis stream (buffered parse streams reliably; `read(n)` truncates)
- [ ] `tox` (no test currently exercises `recv()` framing; happy to add one if desired)
