### PR TITLE
fix: resolve UnboundLocalError in oauth_signin for non-202 error responses

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -865,17 +865,14 @@ async def oauth_signin(auth, email, password, csrf_token):
         OAUTH_SIGNIN_URL, headers=headers, data=data, allow_redirects=False
     )
 
+    response_text = None
+
     if response.status == 412:
         # 2FA required
         return "2FA_REQUIRED"
 
-    if response.status in [301, 302, 303, 307, 308]:
-        # Success without 2FA
-        return "SUCCESS"
-
-    response_text = await response.text()
-
     if response.status == 202:
+        response_text = await response.text()
         try:
             response_json = json.loads(response_text)
         except json.JSONDecodeError:
@@ -889,10 +886,14 @@ async def oauth_signin(auth, email, password, csrf_token):
             # 2FA required (new response format with 202 status code)
             return "2FA_REQUIRED"
 
+    elif response.status in [301, 302, 303, 307, 308]:
+        # Success without 2FA
+        return "SUCCESS"
+
     _LOGGER.error(
         "OAuth signin failed: status=%s body=%s",
         response.status,
-        response_text[:800],
+        (response_text or "")[:800],
     )
 
     return None

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -865,7 +865,7 @@ async def oauth_signin(auth, email, password, csrf_token):
         OAUTH_SIGNIN_URL, headers=headers, data=data, allow_redirects=False
     )
 
-    response_text = None
+    response_text = ""
 
     if response.status == 412:
         # 2FA required
@@ -893,7 +893,7 @@ async def oauth_signin(auth, email, password, csrf_token):
     _LOGGER.error(
         "OAuth signin failed: status=%s body=%s",
         response.status,
-        (response_text or "")[:800],
+        response_text[:800],
     )
 
     return None

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -869,8 +869,13 @@ async def oauth_signin(auth, email, password, csrf_token):
         # 2FA required
         return "2FA_REQUIRED"
 
+    if response.status in [301, 302, 303, 307, 308]:
+        # Success without 2FA
+        return "SUCCESS"
+
+    response_text = await response.text()
+
     if response.status == 202:
-        response_text = await response.text()
         try:
             response_json = json.loads(response_text)
         except json.JSONDecodeError:
@@ -883,10 +888,6 @@ async def oauth_signin(auth, email, password, csrf_token):
         ):
             # 2FA required (new response format with 202 status code)
             return "2FA_REQUIRED"
-
-    elif response.status in [301, 302, 303, 307, 308]:
-        # Success without 2FA
-        return "SUCCESS"
 
     _LOGGER.error(
         "OAuth signin failed: status=%s body=%s",

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -130,6 +130,43 @@ async def test_oauth_signin_2fa_required_202():
 
 
 @pytest.mark.asyncio
+async def test_oauth_signin_202_without_tsv_fields():
+    """Test oauth_signin returns None when 202 response lacks 2FA indicator fields."""
+    auth = Mock()
+    auth.session = Mock()
+
+    response = Mock()
+    response.status = 202
+    response.text = AsyncMock(return_value='{"some_other_field": "value"}')
+    auth.session.post = AsyncMock(return_value=response)
+
+    result = await api.oauth_signin(auth, "test@example.com", "password", "csrf_token")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_signin_unexpected_status_returns_none():
+    """Test oauth_signin returns None without crashing for unexpected status codes.
+
+    Prior to the fix, any status other than 412, 202, or a redirect raised
+    UnboundLocalError because response_text was only assigned inside the
+    202 block but referenced in the error log unconditionally.
+    """
+    auth = Mock()
+    auth.session = Mock()
+
+    response = Mock()
+    response.status = 400
+    response.text = AsyncMock(return_value="Bad Request")
+    auth.session.post = AsyncMock(return_value=response)
+
+    result = await api.oauth_signin(auth, "test@example.com", "password", "csrf_token")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_oauth_verify_2fa():
     """Test 2FA verification."""
     auth = Mock()


### PR DESCRIPTION
  ## Problem

  `oauth_signin()` raised `UnboundLocalError` on any response that wasn't
  412, 202, or a redirect. `response_text` was only assigned inside the
  `if response.status == 202` block, but was referenced unconditionally
  in the `_LOGGER.error()` call at the bottom of the function.

  This exception propagated all the way up through `_oauth_login_flow()`,
  `auth.startup()`, and `blink.start()`, preventing `BlinkTwoFARequiredError`
  from ever being raised — which meant Blink never received the signal to
  send the user a verification code.

  ## Fix

  Read `response_text` unconditionally after the early-return checks for
  412 and redirects, so it is always defined when the error path is reached.
  The redirect success check is moved before `response.text()` to avoid
  the unnecessary read on the happy path.

  ## Testing

  Verified against a live Blink account running Home Assistant Container
  on Kubernetes. Login with 2FA now completes successfully.

  Relates to issue #1230.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
