### PR TITLE
Send validated hardware_id in request_login header (fixes 406 on token refresh)

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -130,7 +130,7 @@ async def request_login(
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
         "User-Agent": DEFAULT_USER_AGENT,
-        "hardware_id": login_data.get("device_id", "Blinkpy"),
+        "hardware_id": auth.hardware_id,
     }
 
     # Add 2FA code to headers if provided

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -277,7 +277,7 @@ class TestAuth(IsolatedAsyncioTestCase):
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
                 "User-Agent": const.DEFAULT_USER_AGENT,
-                "hardware_id": const.DEVICE_ID,
+                "hardware_id": self.auth.hardware_id,
             },
             timeout=10,
         )
@@ -307,7 +307,7 @@ class TestAuth(IsolatedAsyncioTestCase):
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
                 "User-Agent": const.DEFAULT_USER_AGENT,
-                "hardware_id": const.DEVICE_ID,
+                "hardware_id": self.auth.hardware_id,
             },
             timeout=10,
         )

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -363,3 +363,18 @@ async def test_complete_2fa_login():
                 # State should be cleaned up
                 assert not hasattr(auth, "_oauth_csrf_token")
                 assert not hasattr(auth, "_oauth_code_verifier")
+
+
+@pytest.mark.asyncio
+async def test_request_login_sends_auth_hardware_id_header():
+    """Test that request_login sends auth.hardware_id as the hardware_id header."""
+    auth = Mock()
+    auth.query = AsyncMock(return_value=Mock(status=200))
+    auth.refresh_token = "refresh_token"
+    auth.hardware_id = "726D586E-6A27-49E4-B61B-1BB070908899"
+
+    login_data = {"username": "foo", "password": "bar"}
+    await api.request_login(auth, "https://example.com", login_data, is_refresh=True)
+
+    headers = auth.query.call_args.kwargs["headers"]
+    assert headers["hardware_id"] == auth.hardware_id


### PR DESCRIPTION
## Description:

`/oauth/token` rejects requests whose `hardware_id` header is not a valid UUID with `406 Not Acceptable`. `request_login()` sends `login_data["device_id"]` (default `"Blinkpy"`) as that header, so every in-session token refresh fails. The header now uses `auth.hardware_id`, which is guaranteed to be a UUID since #1268.

As offered in #1268 — measurements there: 406 with `Blinkpy`, 200 with a UUID against the live API. The recent reports in #1217 ("Login endpoint failed" ~90 minutes after a restart, restart temporarily fixes it) match this failure mode: startup uses the OAuth v2 refresh path with a proper UUID in the body, while the in-session refresh sends the rejected header.

**Related issue (if applicable):** follow-up to #1268, addresses the refresh failures reported in #1217

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended — refresh grant verified against the live API
- [x] Tests added to verify new code works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
