### PR TITLE
Camera Online Status

### DIFF
--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -119,7 +119,12 @@ class BlinkCamera:
     @property
     def online(self):
         """Return boolean camera online status."""
-        return ONLINE.get(self.status, False)
+        if self.status is None:
+            return False
+        if self.status not in ONLINE:
+            _LOGGER.error("Unknown camera status %s", self.status)
+            return False
+        return ONLINE[self.status]
 
     @property
     def arm(self):

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -11,7 +11,7 @@ import aiohttp
 from aiofiles import open
 from requests.compat import urljoin
 from blinkpy import api
-from blinkpy.helpers.constants import TIMEOUT_MEDIA
+from blinkpy.helpers.constants import TIMEOUT_MEDIA, ONLINE
 from blinkpy.helpers.util import to_alphanumeric
 from blinkpy.livestream import BlinkLiveStream
 
@@ -48,6 +48,8 @@ class BlinkCamera:
         self.camera_type = ""
         self.product_type = None
         self.sync_signal_strength = None
+        self.battery_check_time = None
+        self.status = None
 
     @property
     def attributes(self):
@@ -113,6 +115,15 @@ class BlinkCamera:
     def version(self):
         """Return the camera Firmware version."""
         return self._version
+
+    @property
+    def online(self):
+        """Return boolean camera online status."""
+        try:
+            return ONLINE[self.status]
+        except KeyError:
+            _LOGGER.error("Unknown camera status %s", self.status)
+            return False
 
     @property
     def arm(self):
@@ -301,6 +312,8 @@ class BlinkCamera:
         else:
             self.temperature = config.get("temperature")
         self.product_type = config.get("type")
+        self.battery_check_time = config.get("battery_check_time")
+        self.status = config.get("status")
 
     async def get_sensor_info(self):
         """Retrieve calibrated temperature from special endpoint."""

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -119,11 +119,7 @@ class BlinkCamera:
     @property
     def online(self):
         """Return boolean camera online status."""
-        try:
-            return ONLINE[self.status]
-        except KeyError:
-            _LOGGER.error("Unknown camera status %s", self.status)
-            return False
+        return ONLINE.get(self.status, False)
 
     @property
     def arm(self):

--- a/blinkpy/helpers/constants.py
+++ b/blinkpy/helpers/constants.py
@@ -26,7 +26,7 @@ OAUTH_TOKEN_URL = f"{OAUTH_BASE_URL}/oauth/token"
 """
 Dictionaries
 """
-ONLINE = {"online": True, "offline": False}
+ONLINE = {"online": True, "offline": False, "done": True}
 
 """
 OTHER

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -139,9 +139,7 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         self.camera.battery_check_time = None
         config = {"battery_check_time": "2024-01-01T00:00:00+00:00"}
         self.camera.extract_config_info(config)
-        self.assertEqual(
-            self.camera.battery_check_time, "2024-01-01T00:00:00+00:00"
-        )
+        self.assertEqual(self.camera.battery_check_time, "2024-01-01T00:00:00+00:00")
 
     def test_missing_attributes(self, mock_resp):
         """Test that attributes return None if missing."""

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -102,6 +102,47 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
             self.assertEqual(await self.doorbell.async_arm(True), "arm")
             self.assertEqual(await self.doorbell.async_arm(False), "disarm")
 
+    def test_camera_online_status_online(self, mock_resp):
+        """Test that online property returns True for 'online' status."""
+        self.camera.status = "online"
+        self.assertTrue(self.camera.online)
+
+    def test_camera_online_status_done(self, mock_resp):
+        """Test that online property returns True for 'done' status."""
+        self.camera.status = "done"
+        self.assertTrue(self.camera.online)
+
+    def test_camera_online_status_offline(self, mock_resp):
+        """Test that online property returns False for 'offline' status."""
+        self.camera.status = "offline"
+        self.assertFalse(self.camera.online)
+
+    def test_camera_online_status_unknown(self, mock_resp):
+        """Test that online property returns False for unknown status."""
+        self.camera.status = "unknown_status"
+        self.assertFalse(self.camera.online)
+
+    def test_camera_online_status_none(self, mock_resp):
+        """Test that online property returns False when status is None."""
+        self.camera.status = None
+        self.assertFalse(self.camera.online)
+
+    def test_camera_status_set_in_update(self, mock_resp):
+        """Test that status attribute is set from config in extract_config_info."""
+        self.camera.status = None
+        config = {"status": "online"}
+        self.camera.extract_config_info(config)
+        self.assertEqual(self.camera.status, "online")
+
+    def test_battery_check_time_set_in_update(self, mock_resp):
+        """Test that battery_check_time is set from config in extract_config_info."""
+        self.camera.battery_check_time = None
+        config = {"battery_check_time": "2024-01-01T00:00:00+00:00"}
+        self.camera.extract_config_info(config)
+        self.assertEqual(
+            self.camera.battery_check_time, "2024-01-01T00:00:00+00:00"
+        )
+
     def test_missing_attributes(self, mock_resp):
         """Test that attributes return None if missing."""
         self.camera.temperature = None


### PR DESCRIPTION
## Description:
Adds an `online` property to `BlinkCamera` that returns `True`/`False` based on the camera's current status. Also tracks `status` and `battery_check_time` from the config response, and adds `"done"` as a valid online state to the `ONLINE` constants dict.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
