### PR TITLE
Per Camera Snooze

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -571,14 +571,14 @@ async def request_get_config(blink, network, camera_id, product_type="owl"):
     :param blink: Blink instance.
     :param network: Sync module network id.
     :param camera_id: ID of camera
-    :param product_type: Camera product type "owl" or "catalina"
+    :param product_type: Camera product type "owl", "catalina", or "sedona"
     """
     if product_type == "owl":
         url = (
             f"{blink.urls.base_url}/api/v1/accounts/{blink.account_id}"
             f"/networks/{network}/owls/{camera_id}/config"
         )
-    elif product_type == "catalina":
+    elif product_type in ["catalina", "sedona"]:
         url = f"{blink.urls.base_url}/network/{network}/camera/{camera_id}/config"
     else:
         _LOGGER.info(

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -1074,15 +1074,17 @@ async def request_camera_snooze(
     :param blink: Blink instance.
     :param network: Sync module network id.
     :param camera_id: ID of camera
-    :param product_type: Camera product type "owl", "catalina",
-        "doorbell", "hawk", "lotus", or "sedona"
+    :param product_type: Camera product type "owl", "catalina", "chickadee",
+        "doorbell", "hawk", "lotus", "sedona", or "sonoran"
     :param data: string w/JSON dict of parameters/values to update
     """
     product_lookup = {
         "catalina": "cameras",
         "sedona": "cameras",
+        "sonoran": "cameras",
         "owl": "owls",
         "hawk": "owls",
+        "chickadee": "owls",
         "doorbell": "doorbells",
         "lotus": "doorbells",
     }

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -596,7 +596,7 @@ async def request_update_config(
     :param blink: Blink instance.
     :param network: Sync module network id.
     :param camera_id: ID of camera
-    :param product_type: Camera product type "owl" or "catalina"
+    :param product_type: Camera product type "owl", "catalina", or "sedona"
     :param data: string w/JSON dict of parameters/values to update
     """
     if product_type == "owl":
@@ -604,7 +604,7 @@ async def request_update_config(
             f"{blink.urls.base_url}/api/v1/accounts/"
             f"{blink.account_id}/networks/{network}/owls/{camera_id}/config"
         )
-    elif product_type == "catalina":
+    elif product_type in ["catalina", "sedona"]:
         url = f"{blink.urls.base_url}/network/{network}/camera/{camera_id}/update"
     else:
         _LOGGER.info(

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -1065,3 +1065,41 @@ async def oauth_refresh_token(auth, refresh_token, hardware_id):
         return await response.json()
 
     return None
+
+
+async def request_camera_snooze(
+    blink, network, camera_id, product_type="owl", data=None
+):
+    """
+    Update camera snooze configuration.
+
+    :param blink: Blink instance.
+    :param network: Sync module network id.
+    :param camera_id: ID of camera
+    :param product_type: Camera product type "owl", "catalina",
+        "doorbell", "hawk", "lotus", or "sedona"
+    :param data: string w/JSON dict of parameters/values to update
+    """
+    product_lookup = {
+        "catalina": "cameras",
+        "sedona": "cameras",
+        "owl": "owls",
+        "hawk": "owls",
+        "doorbell": "doorbells",
+        "lotus": "doorbells",
+    }
+
+    if product_type not in product_lookup:
+        _LOGGER.info(
+            "Camera %s with product type %s snooze update not implemented.",
+            camera_id,
+            product_type,
+        )
+        return None
+
+    url_root = (
+        f"{blink.urls.base_url}/api/v1/accounts/{blink.account_id}"
+        f"/networks/{network}"
+    )
+    url = f"{url_root}/{product_lookup[product_type]}/{camera_id}/snooze"
+    return await http_post(blink, url, json=True, data=data)

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -5,6 +5,7 @@ import string
 import os
 import logging
 import datetime
+import math
 from json import dumps
 import traceback
 import aiohttp
@@ -50,6 +51,9 @@ class BlinkCamera:
         self.sync_signal_strength = None
         self.battery_check_time = None
         self.status = None
+        self.snooze = None
+        self.snooze_till = None
+        self.snooze_time_remaining = None
 
     @property
     def attributes(self):
@@ -76,6 +80,9 @@ class BlinkCamera:
             "sync_signal_strength": self.sync_signal_strength,
             "last_record": self.last_record,
             "type": self.product_type,
+            "snooze": self.snooze,
+            "snooze_till": self.snooze_till,
+            "snooze_time_remaining": self.snooze_time_remaining,
         }
         return attributes
 
@@ -389,6 +396,31 @@ class BlinkCamera:
         self.product_type = config.get("type")
         self.battery_check_time = config.get("battery_check_time")
         self.status = config.get("status")
+        self.extract_snooze_info(config)
+
+    def extract_snooze_info(self, config):
+        """Normalize snooze status across camera models (wired vs mini/doorbell)."""
+        self.snooze_till = config.get("snooze_till")
+        remaining = config.get("snooze_time_remaining")
+        snoozed = config.get("snooze")
+
+        if remaining is None and self.snooze_till:
+            try:
+                until = datetime.datetime.fromisoformat(self.snooze_till)
+            except (TypeError, ValueError):
+                _LOGGER.warning(
+                    "Could not parse snooze_till %s for %s", self.snooze_till, self.name
+                )
+            else:
+                if until.tzinfo is None:
+                    until = until.replace(tzinfo=datetime.timezone.utc)
+                seconds = (
+                    until - datetime.datetime.now(datetime.timezone.utc)
+                ).total_seconds()
+                remaining = max(0, math.ceil(seconds / 60))
+
+        self.snooze_time_remaining = remaining
+        self.snooze = bool(remaining) if snoozed is None else bool(snoozed)
 
     async def get_sensor_info(self):
         """Retrieve calibrated temperature from special endpoint."""

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -226,12 +226,24 @@ class BlinkCamera:
             )
             return False
 
-    async def async_snooze(self, snooze_time=3600):
+    async def async_snooze(self, snooze_time=60):
         """
         Set camera snooze status.
 
-        :param snooze_time: Time in seconds to snooze camera. Default is 3600 (1 hour).
+        :param snooze_time: Time in minutes to snooze camera. Default is 60
+            (1 hour). Valid values are 1-1439; the API rejects 0 and values
+            of 1440 or greater. There is no dedicated call to cancel a
+            snooze, so sending snooze_time=1 is the practical way to end one
+            almost immediately.
         """
+        if not 1 <= snooze_time <= 1439:
+            _LOGGER.warning(
+                "Invalid snooze_time %s for camera %s; must be between "
+                "1 and 1439 minutes.",
+                snooze_time,
+                self.camera_id,
+            )
+            return None
         data = dumps({"snooze_time": snooze_time})
         res = await api.request_camera_snooze(
             self.sync.blink,
@@ -240,6 +252,13 @@ class BlinkCamera:
             product_type=self.product_type,
             data=data,
         )
+        if isinstance(res, dict) and "code" in res:
+            _LOGGER.warning(
+                "Camera %s snooze request rejected: %s",
+                self.camera_id,
+                res.get("message"),
+            )
+            return res
         if res and self.product_type not in ["catalina", "sedona"]:
             await self.sync.blink.get_homescreen()
         return res

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -178,6 +178,61 @@ class BlinkCamera:
         return None
 
     @property
+    async def snoozed(self):
+        """Return snooze status as boolean."""
+        response_data = None
+        try:
+            if self.product_type in ["catalina", "sedona"]:
+                res = await api.request_get_config(
+                    self.sync.blink,
+                    self.network_id,
+                    self.camera_id,
+                    product_type=self.product_type,
+                )
+                response_data = res
+                snooze_value = res["camera"][0].get("snooze_till")
+                return bool(snooze_value)
+            else:
+                response_data = self.sync.blink.homescreen
+                if self.product_type in ["doorbell", "lotus"]:
+                    collection_key = "doorbells"
+                else:
+                    collection_key = "owls"
+                for device in self.sync.blink.homescreen.get(collection_key, []):
+                    if int(device.get("id")) == int(self.camera_id):
+                        snooze_value = device.get("snooze")
+                        return bool(snooze_value)
+                return False
+        except TypeError:
+            return False
+        except (IndexError, KeyError, ValueError) as e:
+            _LOGGER.warning(
+                "Exception %s: Encountered a likely malformed response "
+                "from the snooze API endpoint. Response: %s",
+                e,
+                response_data,
+            )
+            return False
+
+    async def async_snooze(self, snooze_time=3600):
+        """
+        Set camera snooze status.
+
+        :param snooze_time: Time in seconds to snooze camera. Default is 3600 (1 hour).
+        """
+        data = dumps({"snooze_time": snooze_time})
+        res = await api.request_camera_snooze(
+            self.sync.blink,
+            self.network_id,
+            self.camera_id,
+            product_type=self.product_type,
+            data=data,
+        )
+        if res and self.product_type not in ["catalina", "sedona"]:
+            await self.sync.blink.get_homescreen()
+        return res
+
+    @property
     def floodlight_enabled(self):
         """Return last-known floodlight state if tracked, else None."""
         return getattr(self, "_floodlight_enabled", None)

--- a/blinkpy/camera.py
+++ b/blinkpy/camera.py
@@ -199,7 +199,7 @@ class BlinkCamera:
                 else:
                     collection_key = "owls"
                 for device in self.sync.blink.homescreen.get(collection_key, []):
-                    if int(device.get("id")) == int(self.camera_id):
+                    if str(device.get("id")) == str(self.camera_id):
                         snooze_value = device.get("snooze")
                         return bool(snooze_value)
                 return False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -189,6 +189,46 @@ class TestAPI(IsolatedAsyncioTestCase):
             )
         )
 
+    async def test_request_camera_snooze(self, mock_resp):
+        """Test camera snooze request."""
+        mock_resp.return_value = {"message": "Camera snoozed"}
+        # Test catalina camera
+        response = await api.request_camera_snooze(
+            self.blink, "network", "camera_id", "catalina", '{"snooze": 300}'
+        )
+        self.assertEqual(response, {"message": "Camera snoozed"})
+        # Test sedona camera
+        response = await api.request_camera_snooze(
+            self.blink, "network", "camera_id", "sedona", '{"snooze": 300}'
+        )
+        self.assertEqual(response, {"message": "Camera snoozed"})
+        # Test owl camera
+        response = await api.request_camera_snooze(
+            self.blink, "network", "camera_id", "owl", '{"snooze": 300}'
+        )
+        self.assertEqual(response, {"message": "Camera snoozed"})
+        # Test hawk camera
+        response = await api.request_camera_snooze(
+            self.blink, "network", "camera_id", "hawk", '{"snooze": 300}'
+        )
+        self.assertEqual(response, {"message": "Camera snoozed"})
+        # Test doorbell camera
+        response = await api.request_camera_snooze(
+            self.blink, "network", "camera_id", "doorbell", '{"snooze": 300}'
+        )
+        self.assertEqual(response, {"message": "Camera snoozed"})
+        # Test lotus camera
+        response = await api.request_camera_snooze(
+            self.blink, "network", "camera_id", "lotus", '{"snooze": 300}'
+        )
+        self.assertEqual(response, {"message": "Camera snoozed"})
+        # Test unsupported camera type
+        self.assertIsNone(
+            await api.request_camera_snooze(
+                self.blink, "network", "camera_id", "unsupported_type"
+            )
+        )
+
     async def test_wait_for_command(self, mock_resp):
         """Test Motion detect enable."""
         mock_resp.side_effect = (COMMAND_NOT_COMPLETE, COMMAND_COMPLETE)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -194,32 +194,32 @@ class TestAPI(IsolatedAsyncioTestCase):
         mock_resp.return_value = {"message": "Camera snoozed"}
         # Test catalina camera
         response = await api.request_camera_snooze(
-            self.blink, "network", "camera_id", "catalina", '{"snooze": 300}'
+            self.blink, "network", "camera_id", "catalina", '{"snooze_time": 300}'
         )
         self.assertEqual(response, {"message": "Camera snoozed"})
         # Test sedona camera
         response = await api.request_camera_snooze(
-            self.blink, "network", "camera_id", "sedona", '{"snooze": 300}'
+            self.blink, "network", "camera_id", "sedona", '{"snooze_time": 300}'
         )
         self.assertEqual(response, {"message": "Camera snoozed"})
         # Test owl camera
         response = await api.request_camera_snooze(
-            self.blink, "network", "camera_id", "owl", '{"snooze": 300}'
+            self.blink, "network", "camera_id", "owl", '{"snooze_time": 300}'
         )
         self.assertEqual(response, {"message": "Camera snoozed"})
         # Test hawk camera
         response = await api.request_camera_snooze(
-            self.blink, "network", "camera_id", "hawk", '{"snooze": 300}'
+            self.blink, "network", "camera_id", "hawk", '{"snooze_time": 300}'
         )
         self.assertEqual(response, {"message": "Camera snoozed"})
         # Test doorbell camera
         response = await api.request_camera_snooze(
-            self.blink, "network", "camera_id", "doorbell", '{"snooze": 300}'
+            self.blink, "network", "camera_id", "doorbell", '{"snooze_time": 300}'
         )
         self.assertEqual(response, {"message": "Camera snoozed"})
         # Test lotus camera
         response = await api.request_camera_snooze(
-            self.blink, "network", "camera_id", "lotus", '{"snooze": 300}'
+            self.blink, "network", "camera_id", "lotus", '{"snooze_time": 300}'
         )
         self.assertEqual(response, {"message": "Camera snoozed"})
         # Test unsupported camera type

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -202,6 +202,11 @@ class TestAPI(IsolatedAsyncioTestCase):
             self.blink, "network", "camera_id", "sedona", '{"snooze_time": 300}'
         )
         self.assertEqual(response, {"message": "Camera snoozed"})
+        # Test sonoran camera
+        response = await api.request_camera_snooze(
+            self.blink, "network", "camera_id", "sonoran", '{"snooze_time": 300}'
+        )
+        self.assertEqual(response, {"message": "Camera snoozed"})
         # Test owl camera
         response = await api.request_camera_snooze(
             self.blink, "network", "camera_id", "owl", '{"snooze_time": 300}'
@@ -210,6 +215,11 @@ class TestAPI(IsolatedAsyncioTestCase):
         # Test hawk camera
         response = await api.request_camera_snooze(
             self.blink, "network", "camera_id", "hawk", '{"snooze_time": 300}'
+        )
+        self.assertEqual(response, {"message": "Camera snoozed"})
+        # Test chickadee camera
+        response = await api.request_camera_snooze(
+            self.blink, "network", "camera_id", "chickadee", '{"snooze_time": 300}'
         )
         self.assertEqual(response, {"message": "Camera snoozed"})
         # Test doorbell camera

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -277,18 +277,54 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
 
     @mock.patch(
         "blinkpy.api.request_camera_snooze",
-        mock.AsyncMock(return_value={"status": 400}),
+        mock.AsyncMock(
+            return_value={"message": "Unsupported value for snooze time", "code": 2800}
+        ),
     )
-    async def test_camera_snooze_failure(self, mock_resp):
-        """Test camera snooze failure."""
+    async def test_camera_snooze_rejected(self, mock_resp):
+        """Test camera snooze rejected by the API (HTTP 200 with error code)."""
         self.camera.product_type = "owl"
         with mock.patch.object(
             self.blink, "get_homescreen", mock.AsyncMock()
         ) as mock_homescreen:
             result = await self.camera.async_snooze(300)
-            # Non-catalina/sedona cameras refresh homescreen even on failure
-            mock_homescreen.assert_called_once()
-        self.assertEqual(result, {"status": 400})
+            # A rejected snooze request should not trigger a homescreen refresh
+            mock_homescreen.assert_not_called()
+        self.assertEqual(
+            result, {"message": "Unsupported value for snooze time", "code": 2800}
+        )
+
+    async def test_camera_snooze_invalid_time_too_low(self, mock_resp):
+        """Test camera snooze rejects a snooze_time of 0 without calling the API."""
+        self.camera.product_type = "owl"
+        with mock.patch(
+            "blinkpy.api.request_camera_snooze", mock.AsyncMock()
+        ) as mock_snooze:
+            result = await self.camera.async_snooze(0)
+            mock_snooze.assert_not_called()
+        self.assertIsNone(result)
+
+    async def test_camera_snooze_invalid_time_too_high(self, mock_resp):
+        """Test camera snooze rejects a snooze_time of 1440 without calling the API."""
+        self.camera.product_type = "owl"
+        with mock.patch(
+            "blinkpy.api.request_camera_snooze", mock.AsyncMock()
+        ) as mock_snooze:
+            result = await self.camera.async_snooze(1440)
+            mock_snooze.assert_not_called()
+        self.assertIsNone(result)
+
+    async def test_camera_snooze_default_time(self, mock_resp):
+        """Test camera snooze uses a 60 minute (1 hour) default."""
+        self.camera.product_type = "catalina"
+        with mock.patch(
+            "blinkpy.api.request_camera_snooze",
+            mock.AsyncMock(return_value={"message": "Snooze set for Camera"}),
+        ) as mock_snooze:
+            await self.camera.async_snooze()
+            self.assertEqual(
+                mock_snooze.call_args.kwargs["data"], '{"snooze_time": 60}'
+            )
 
     @mock.patch(
         "blinkpy.api.request_camera_snooze",

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -220,3 +220,244 @@ class TestBlinkCameraSetup(IsolatedAsyncioTestCase):
         self.assertEqual(
             self.camera.thumbnail, f"https://rest-test.immedia-semi.com{thumb_return}"
         )
+
+    @mock.patch(
+        "blinkpy.api.request_camera_snooze",
+        mock.AsyncMock(return_value={"status": 200}),
+    )
+    async def test_camera_snooze(self, mock_resp):
+        """Test camera snooze."""
+        self.camera.product_type = "catalina"
+        with mock.patch.object(
+            self.blink, "get_homescreen", mock.AsyncMock()
+        ) as mock_homescreen:
+            result = await self.camera.async_snooze(300)
+            # Catalina cameras should NOT refresh homescreen
+            mock_homescreen.assert_not_called()
+        self.assertEqual(result, {"status": 200})
+
+    @mock.patch(
+        "blinkpy.api.request_camera_snooze",
+        mock.AsyncMock(return_value={"status": 400}),
+    )
+    async def test_camera_snooze_failure(self, mock_resp):
+        """Test camera snooze failure."""
+        self.camera.product_type = "owl"
+        with mock.patch.object(
+            self.blink, "get_homescreen", mock.AsyncMock()
+        ) as mock_homescreen:
+            result = await self.camera.async_snooze(300)
+            # Non-catalina/sedona cameras refresh homescreen even on failure
+            mock_homescreen.assert_called_once()
+        self.assertEqual(result, {"status": 400})
+
+    @mock.patch(
+        "blinkpy.api.request_camera_snooze",
+        mock.AsyncMock(return_value=None),
+    )
+    async def test_camera_snooze_none_response(self, mock_resp):
+        """Test camera snooze with None response."""
+        self.camera.product_type = "doorbell"
+        with mock.patch.object(
+            self.blink, "get_homescreen", mock.AsyncMock()
+        ) as mock_homescreen:
+            result = await self.camera.async_snooze(240)
+            # get_homescreen should not be called when response is None
+            mock_homescreen.assert_not_called()
+        self.assertIsNone(result)
+
+    @mock.patch(
+        "blinkpy.api.request_camera_snooze",
+        mock.AsyncMock(return_value={"status": 200}),
+    )
+    async def test_camera_snooze_mini(self, mock_resp):
+        """Test mini camera snooze refreshes homescreen."""
+        self.camera.product_type = "mini"
+        with mock.patch.object(
+            self.blink, "get_homescreen", mock.AsyncMock()
+        ) as mock_homescreen:
+            result = await self.camera.async_snooze(300)
+            # Mini cameras should refresh homescreen
+            mock_homescreen.assert_called_once()
+        self.assertEqual(result, {"status": 200})
+
+    @mock.patch(
+        "blinkpy.api.request_camera_snooze",
+        mock.AsyncMock(return_value={"status": 200}),
+    )
+    async def test_camera_snooze_sedona(self, mock_resp):
+        """Test sedona camera snooze does not refresh homescreen."""
+        self.camera.product_type = "sedona"
+        with mock.patch.object(
+            self.blink, "get_homescreen", mock.AsyncMock()
+        ) as mock_homescreen:
+            result = await self.camera.async_snooze(300)
+            # Sedona cameras should NOT refresh homescreen
+            mock_homescreen.assert_not_called()
+        self.assertEqual(result, {"status": 200})
+
+    @mock.patch(
+        "blinkpy.api.request_get_config",
+        mock.AsyncMock(
+            return_value={"camera": [{"snooze_till": "2026-02-15T12:00:00+00:00"}]}
+        ),
+    )
+    async def test_camera_snoozed_catalina(self, mock_resp):
+        """Test getting snoozed status for catalina camera."""
+        self.camera.product_type = "catalina"
+        self.camera.network_id = "5678"
+        self.camera.camera_id = "1234"
+        result = await self.camera.snoozed
+        self.assertTrue(result)
+
+    async def test_camera_snoozed_owl(self, mock_resp):
+        """Test getting snoozed status for owl camera."""
+        self.camera.product_type = "owl"
+        self.camera.camera_id = "1234"
+        self.blink.homescreen = {
+            "owls": [{"id": "1234", "snooze": "2026-02-15T12:00:00+00:00"}]
+        }
+        result = await self.camera.snoozed
+        self.assertTrue(result)
+
+    async def test_camera_snoozed_owl_false(self, mock_resp):
+        """Test getting snoozed status returns False when not snoozed."""
+        self.camera.product_type = "owl"
+        self.camera.camera_id = "9999"
+        self.blink.homescreen = {
+            "owls": [{"id": "1234", "snooze": "2026-02-15T12:00:00+00:00"}]
+        }
+        result = await self.camera.snoozed
+        self.assertFalse(result)
+
+    async def test_camera_snoozed_doorbell(self, mock_resp):
+        """Test getting snoozed status for doorbell camera."""
+        self.camera.product_type = "doorbell"
+        self.camera.camera_id = "5678"
+        self.blink.homescreen = {
+            "doorbells": [{"id": "5678", "snooze": "2026-02-15T12:00:00+00:00"}]
+        }
+        result = await self.camera.snoozed
+        self.assertTrue(result)
+
+    async def test_camera_snoozed_lotus(self, mock_resp):
+        """Test getting snoozed status for lotus (doorbell) camera."""
+        self.camera.product_type = "lotus"
+        self.camera.camera_id = "5678"
+        self.blink.homescreen = {
+            "doorbells": [{"id": "5678", "snooze": "2026-02-15T12:00:00+00:00"}]
+        }
+        result = await self.camera.snoozed
+        self.assertTrue(result)
+
+    async def test_camera_snoozed_hawk(self, mock_resp):
+        """Test getting snoozed status for hawk camera."""
+        self.camera.product_type = "hawk"
+        self.camera.camera_id = "1234"
+        self.blink.homescreen = {
+            "owls": [{"id": "1234", "snooze": "2026-02-15T12:00:00+00:00"}]
+        }
+        result = await self.camera.snoozed
+        self.assertTrue(result)
+
+    @mock.patch(
+        "blinkpy.api.request_get_config",
+        mock.AsyncMock(
+            return_value={"camera": [{"snooze_till": "2026-02-15T12:00:00+00:00"}]}
+        ),
+    )
+    async def test_camera_snoozed_sedona(self, mock_resp):
+        """Test getting snoozed status for sedona camera."""
+        self.camera.product_type = "sedona"
+        self.camera.network_id = "5678"
+        self.camera.camera_id = "1234"
+        result = await self.camera.snoozed
+        self.assertTrue(result)
+
+    async def test_camera_snoozed_boolean_true(self, mock_resp):
+        """Test getting snoozed status when snooze is boolean True."""
+        self.camera.product_type = "owl"
+        self.camera.camera_id = "1234"
+        self.blink.homescreen = {"owls": [{"id": "1234", "snooze": True}]}
+        result = await self.camera.snoozed
+        self.assertTrue(result)
+
+    async def test_camera_snoozed_boolean_false(self, mock_resp):
+        """Test getting snoozed status when snooze is boolean False."""
+        self.camera.product_type = "owl"
+        self.camera.camera_id = "1234"
+        self.blink.homescreen = {"owls": [{"id": "1234", "snooze": False}]}
+        result = await self.camera.snoozed
+        self.assertFalse(result)
+
+    async def test_camera_snoozed_mini(self, mock_resp):
+        """Test getting snoozed status for mini camera from homescreen."""
+        self.camera.product_type = "mini"
+        self.camera.camera_id = "1234"
+        self.blink.homescreen = {
+            "owls": [{"id": "1234", "snooze": "2026-02-15T12:00:00+00:00"}]
+        }
+        result = await self.camera.snoozed
+        self.assertTrue(result)
+
+    async def test_camera_snoozed_mini_false(self, mock_resp):
+        """Test getting snoozed status for mini camera returns False."""
+        self.camera.product_type = "mini"
+        self.camera.camera_id = "9999"
+        self.blink.homescreen = {
+            "owls": [{"id": "1234", "snooze": "2026-02-15T12:00:00+00:00"}]
+        }
+        result = await self.camera.snoozed
+        self.assertFalse(result)
+
+    async def test_camera_snoozed_empty_homescreen(self, mock_resp):
+        """Test getting snoozed status with empty homescreen collection."""
+        self.camera.product_type = "owl"
+        self.camera.camera_id = "1234"
+        self.blink.homescreen = {"owls": []}
+        result = await self.camera.snoozed
+        self.assertFalse(result)
+
+    async def test_camera_snoozed_missing_collection(self, mock_resp):
+        """Test getting snoozed status when homescreen collection is missing."""
+        self.camera.product_type = "doorbell"
+        self.camera.camera_id = "5678"
+        self.blink.homescreen = {"owls": []}
+        result = await self.camera.snoozed
+        self.assertFalse(result)
+
+    @mock.patch(
+        "blinkpy.api.request_get_config",
+        mock.AsyncMock(return_value=None),
+    )
+    async def test_camera_snoozed_none(self, mock_resp):
+        """Test getting snoozed status with None response."""
+        self.camera.product_type = "catalina"
+        self.camera.network_id = "5678"
+        self.camera.camera_id = "1234"
+        result = await self.camera.snoozed
+        self.assertFalse(result)
+
+    @mock.patch(
+        "blinkpy.api.request_get_config",
+        mock.AsyncMock(return_value={"camera": [{}]}),
+    )
+    async def test_camera_snoozed_malformed(self, mock_resp):
+        """Test getting snoozed status with malformed response."""
+        self.camera.product_type = "catalina"
+        self.camera.network_id = "5678"
+        self.camera.camera_id = "1234"
+        result = await self.camera.snoozed
+        self.assertFalse(result)
+
+    @mock.patch(
+        "blinkpy.api.request_get_config",
+        mock.AsyncMock(return_value={"camera": [{"snooze_till": ""}]}),
+    )
+    async def test_camera_snoozed_empty_string(self, mock_resp):
+        """Test getting snoozed status with empty string."""
+        self.camera.product_type = "catalina"
+        self.camera.network_id = "5678"
+        self.camera.camera_id = "1234"
+        result = await self.camera.snoozed
+        self.assertFalse(result)


### PR DESCRIPTION
## Description:
Adds `async_snooze()` and a `snoozed` property to `BlinkCamera` so individual cameras can be snoozed. A new `request_camera_snooze()` API function handles routing to the right endpoint per product type (`catalina`/`sedona` → cameras, `owl`/`hawk` → owls, `doorbell`/`lotus` → doorbells).

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
