### PR TITLE
Sync Module Snooze

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -1069,14 +1069,17 @@ async def oauth_refresh_token(auth, refresh_token, hardware_id):
 
 async def request_sync_snooze(blink, network, data=None):
     """
-    Update sync snooze configuration.
+    Get or update sync snooze configuration.
 
     :param blink: Blink instance.
     :param network: Sync module network id.
-    :param data: string w/JSON dict of parameters/values to update
+    :param data: string w/JSON dict of parameters/values to update.
+        If None, performs a GET to read current snooze state.
     """
     url = (
         f"{blink.urls.base_url}/api/v1/accounts/{blink.account_id}"
         f"/networks/{network}/snooze"
     )
+    if data is None:
+        return await http_get(blink, url)
     return await http_post(blink, url, json=True, data=data)

--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -1065,3 +1065,18 @@ async def oauth_refresh_token(auth, refresh_token, hardware_id):
         return await response.json()
 
     return None
+
+
+async def request_sync_snooze(blink, network, data=None):
+    """
+    Update sync snooze configuration.
+
+    :param blink: Blink instance.
+    :param network: Sync module network id.
+    :param data: string w/JSON dict of parameters/values to update
+    """
+    url = (
+        f"{blink.urls.base_url}/api/v1/accounts/{blink.account_id}"
+        f"/networks/{network}/snooze"
+    )
+    return await http_post(blink, url, json=True, data=data)

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -132,23 +132,17 @@ class BlinkSyncModule:
         """Return snooze status as boolean."""
         res = None
         try:
-            res = await api.request_sync_snooze(
-                self.blink,
-                self.network_id,
-            )
-            if res is None:
+            res = await api.request_sync_snooze(self.blink, self.network_id)
+            if not isinstance(res, dict):
                 return False
-            snooze_value = res.get("snooze_till")
-            return bool(snooze_value)
-        except TypeError:
-            return False
-        except KeyError as e:
-            _LOGGER.warning(
-                "Exception %s: Encountered a likely malformed response "
-                "from the snooze API endpoint. Response: %s",
-                e,
-                res,
-            )
+            snooze_till = res.get("snooze_till")
+            if not snooze_till:
+                return False
+            expiry = datetime.datetime.fromisoformat(snooze_till)
+            if expiry.tzinfo is None:
+                expiry = expiry.replace(tzinfo=datetime.timezone.utc)
+            return expiry > datetime.datetime.now(datetime.timezone.utc)
+        except (TypeError, ValueError):
             return False
 
     async def async_snooze(self, snooze_time=240):

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -127,6 +127,40 @@ class BlinkSyncModule:
             return await api.request_system_arm(self.blink, self.network_id)
         return await api.request_system_disarm(self.blink, self.network_id)
 
+    @property
+    async def snoozed(self):
+        """Return snooze status as boolean."""
+        res = None
+        try:
+            res = await api.request_sync_snooze(
+                self.blink,
+                self.network_id,
+            )
+            if res is None:
+                return False
+            snooze_value = res.get("snooze_till")
+            return bool(snooze_value)
+        except TypeError:
+            return False
+        except KeyError as e:
+            _LOGGER.warning(
+                "Exception %s: Encountered a likely malformed response "
+                "from the snooze API endpoint. Response: %s",
+                e,
+                res,
+            )
+            return False
+
+    async def async_snooze(self, snooze_time=240):
+        """Set sync snooze status."""
+        data = json_dumps({"snooze_time": snooze_time})
+        res = await api.request_sync_snooze(
+            self.blink,
+            self.network_id,
+            data=data,
+        )
+        return res
+
     async def start(self):
         """Initialize the system."""
         _LOGGER.debug("Initializing the sync module")

--- a/blinkpy/sync_module.py
+++ b/blinkpy/sync_module.py
@@ -138,7 +138,7 @@ class BlinkSyncModule:
             snooze_till = res.get("snooze_till")
             if not snooze_till:
                 return False
-            expiry = datetime.datetime.fromisoformat(snooze_till)
+            expiry = datetime.datetime.fromisoformat(snooze_till.replace("Z", "+00:00"))
             if expiry.tzinfo is None:
                 expiry = expiry.replace(tzinfo=datetime.timezone.utc)
             return expiry > datetime.datetime.now(datetime.timezone.utc)
@@ -147,7 +147,7 @@ class BlinkSyncModule:
 
     async def async_snooze(self, snooze_time=240):
         """Set sync snooze status."""
-        data = json_dumps({"snooze_time": snooze_time})
+        data = json_dumps({"snooze_time": snooze_time}, indent=None)
         res = await api.request_sync_snooze(
             self.blink,
             self.network_id,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -193,7 +193,7 @@ class TestAPI(IsolatedAsyncioTestCase):
         """Test sync snooze request."""
         mock_resp.return_value = {"message": "Sync snoozed"}
         response = await api.request_sync_snooze(
-            self.blink, "network", '{"snooze": 300}'
+            self.blink, "network", '{"snooze_time": 300}'
         )
         self.assertEqual(response, {"message": "Sync snoozed"})
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -189,6 +189,14 @@ class TestAPI(IsolatedAsyncioTestCase):
             )
         )
 
+    async def test_request_sync_snooze(self, mock_resp):
+        """Test sync snooze request."""
+        mock_resp.return_value = {"message": "Sync snoozed"}
+        response = await api.request_sync_snooze(
+            self.blink, "network", '{"snooze": 300}'
+        )
+        self.assertEqual(response, {"message": "Sync snoozed"})
+
     async def test_wait_for_command(self, mock_resp):
         """Test Motion detect enable."""
         mock_resp.side_effect = (COMMAND_NOT_COMPLETE, COMMAND_COMPLETE)

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -138,6 +138,24 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
 
     @mock.patch(
         "blinkpy.api.request_sync_snooze",
+        mock.AsyncMock(return_value={"snooze_till": "2000-01-01T00:00:00+00:00"}),
+    )
+    async def test_snoozed_expired(self, mock_resp) -> None:
+        """Check that expired snooze_till returns False."""
+        result = await self.blink.sync["test"].snoozed
+        self.assertFalse(result)
+
+    @mock.patch(
+        "blinkpy.api.request_sync_snooze",
+        mock.AsyncMock(return_value={"snooze_till": "2099-01-01T00:00:00Z"}),
+    )
+    async def test_snoozed_z_suffix(self, mock_resp) -> None:
+        """Check that Z-suffix timestamps are parsed correctly."""
+        result = await self.blink.sync["test"].snoozed
+        self.assertTrue(result)
+
+    @mock.patch(
+        "blinkpy.api.request_sync_snooze",
         mock.AsyncMock(return_value={"status": 200}),
     )
     async def test_async_snooze(self, mock_resp) -> None:

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -100,6 +100,69 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
         self.blink.homescreen = {"doorbells": [device], "owls": []}
         self.assertEqual(self.blink.sync["test"].get_unique_info("doorbell2"), None)
 
+    @mock.patch(
+        "blinkpy.api.request_sync_snooze",
+        mock.AsyncMock(return_value={"snooze_till": "2026-02-15T12:00:00+00:00"}),
+    )
+    async def test_snoozed(self, mock_resp) -> None:
+        """Check that we get snoozed status."""
+        result = await self.blink.sync["test"].snoozed
+        self.assertTrue(result)
+
+    @mock.patch(
+        "blinkpy.api.request_sync_snooze",
+        mock.AsyncMock(return_value=None),
+    )
+    async def test_snoozed_none(self, mock_resp) -> None:
+        """Check that we handle None response."""
+        result = await self.blink.sync["test"].snoozed
+        self.assertFalse(result)
+
+    @mock.patch(
+        "blinkpy.api.request_sync_snooze",
+        mock.AsyncMock(return_value={}),
+    )
+    async def test_snoozed_malformed(self, mock_resp) -> None:
+        """Check that we handle malformed response."""
+        result = await self.blink.sync["test"].snoozed
+        self.assertFalse(result)
+
+    @mock.patch(
+        "blinkpy.api.request_sync_snooze",
+        mock.AsyncMock(return_value={"snooze_till": ""}),
+    )
+    async def test_snoozed_empty_string(self, mock_resp) -> None:
+        """Check that we handle empty string response."""
+        result = await self.blink.sync["test"].snoozed
+        self.assertFalse(result)
+
+    @mock.patch(
+        "blinkpy.api.request_sync_snooze",
+        mock.AsyncMock(return_value={"status": 200}),
+    )
+    async def test_async_snooze(self, mock_resp) -> None:
+        """Check that we can set snooze."""
+        result = await self.blink.sync["test"].async_snooze(300)
+        self.assertEqual(result, {"status": 200})
+
+    @mock.patch(
+        "blinkpy.api.request_sync_snooze",
+        mock.AsyncMock(return_value={"status": 400}),
+    )
+    async def test_async_snooze_failure(self, mock_resp) -> None:
+        """Check that we handle snooze failure."""
+        result = await self.blink.sync["test"].async_snooze(300)
+        self.assertEqual(result, {"status": 400})
+
+    @mock.patch(
+        "blinkpy.api.request_sync_snooze",
+        mock.AsyncMock(return_value=None),
+    )
+    async def test_async_snooze_none_response(self, mock_resp) -> None:
+        """Check that we handle None response when setting snooze."""
+        result = await self.blink.sync["test"].async_snooze(300)
+        self.assertIsNone(result)
+
     async def test_get_events(self, mock_resp) -> None:
         """Test get events function."""
         mock_resp.return_value = {"event": True}

--- a/tests/test_sync_module.py
+++ b/tests/test_sync_module.py
@@ -102,7 +102,7 @@ class TestBlinkSyncModule(IsolatedAsyncioTestCase):
 
     @mock.patch(
         "blinkpy.api.request_sync_snooze",
-        mock.AsyncMock(return_value={"snooze_till": "2026-02-15T12:00:00+00:00"}),
+        mock.AsyncMock(return_value={"snooze_till": "2099-01-01T12:00:00+00:00"}),
     )
     async def test_snoozed(self, mock_resp) -> None:
         """Check that we get snoozed status."""


### PR DESCRIPTION
## Description:
Adds `async_snooze()` and a `snoozed` property to `BlinkSyncModule` for snoozing at the network level. Uses GET to read snooze state and POST to set it via a new `request_sync_snooze()` API function. The `snoozed` property checks the `snooze_till` timestamp against the current time so it correctly returns `False` once a snooze has expired.

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
