### PR TITLE
Relax aiofiles requirement to >=23.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ requests>=2.34.2
 python-slugify>=8.0.4
 sortedcontainers~=2.4.0
 aiohttp>=3.14.1
-aiofiles>=25.1.0
+aiofiles>=23.1.0


### PR DESCRIPTION
## Description:

Relax the `aiofiles` lower bound from `>=25.1.0` back to `>=23.1.0`.

The `>=25.1.0` floor came from a routine dependabot bump (cdb90e6f, 2026-06-19)
that mechanically raised the minimum to the then-latest release; it isn't
required by the code. blinkpy only uses `aiofiles.open()` and
`aiofiles.ospath.isfile()`, both available since aiofiles 23.1.0 — which is why
the floor was `>=23.1.0` before that bump.

The high floor blocks downstreams that are constrained to aiofiles 24.1.0 from
adopting recent blinkpy. In particular, Home Assistant's `matrix` integration
pins `aiofiles==24.1.0` (via `matrix-nio`), which cannot co-resolve with
`aiofiles>=25.1.0` — so Home Assistant can't bump blinkpy past 0.25.6, leaving
users without the 0.25.7/0.25.8 OAuth/2FA fixes (downstream reports:
home-assistant/core#176836, home-assistant/core#176708). I've been running
blinkpy 0.25.8 against aiofiles 24.1.0 with no issues.

Happy to use `>=24.1.0` instead if you'd prefer a tighter floor.

**Related issue (if applicable):** n/a (downstream: home-assistant/core#176836)

## Checklist:
- [ ] Local tests with `tox` run successfully — not run locally; this is a
  metadata-only change (dependency floor), no code paths touched. CI covers it.
- [x] Changes tested locally to ensure platform still works as intended —
  verified blinkpy 0.25.8 runs against aiofiles 24.1.0 at runtime.
- [ ] Tests added to verify new code works — n/a (no code change).
