### PR TITLE
fix(util): emit UTC offset from get_time

### DIFF
--- a/blinkpy/helpers/util.py
+++ b/blinkpy/helpers/util.py
@@ -8,6 +8,7 @@ import secrets
 import re
 from asyncio import sleep
 from calendar import timegm
+from datetime import datetime, timezone
 from functools import wraps
 from getpass import getpass
 import aiofiles
@@ -69,7 +70,9 @@ def get_time(time_to_convert=None):
     """Create blink-compatible timestamp."""
     if time_to_convert is None:
         time_to_convert = time.time()
-    return time.strftime(const.TIMESTAMP_FORMAT, time.gmtime(time_to_convert))
+    return datetime.fromtimestamp(time_to_convert, timezone.utc).strftime(
+        const.TIMESTAMP_FORMAT
+    )
 
 
 def merge_dicts(dict_a, dict_b):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@
 
 from unittest import mock, IsolatedAsyncioTestCase
 import time
+from datetime import datetime, timezone
 import aiofiles
 from io import BufferedIOBase
 from blinkpy.helpers.util import (
@@ -194,8 +195,15 @@ class TestUtil(IsolatedAsyncioTestCase):
     def test_get_time(self):
         """Test the get time util."""
         self.assertEqual(
-            get_time(), time.strftime(const.TIMESTAMP_FORMAT, time.gmtime(time.time()))
+            get_time(),
+            datetime.now(timezone.utc).strftime(const.TIMESTAMP_FORMAT),
         )
+
+    def test_get_time_is_utc(self):
+        """Test that get_time reports UTC fields with a UTC offset."""
+        epoch = 1700000000
+        self.assertEqual(get_time(epoch), "2023-11-14T22:13:20+0000")
+        self.assertEqual(time_to_seconds(get_time(epoch)), epoch)
 
     def test_merge_dicts(self):
         """Test for duplicates message in merge dicts."""


### PR DESCRIPTION
## Description:

`get_time()` built its timestamp from `time.gmtime()` but formatted it with `time.strftime()`, whose `%z` directive always renders the *local* UTC offset. The fields were UTC while the offset was local, so on a UTC-5 host `get_time(1700000000)` returned `2023-11-14T22:13:20-0500` — a string that parses back to a moment five hours later than intended. Every `media/changed?since=` query built by `api.request_videos` was skewed by the host offset, which is why recent clips were missing from `get_videos_metadata()` until the caller over-widened the window.

The fix formats a timezone-aware UTC datetime so the fields and the offset describe the same instant.

**Related issue (if applicable):** fixes #1144

## Checklist:
- [x] Local tests with `tox` run successfully **PR cannot be meged unless tests pass**
- [x] Changes tested locally to ensure platform still works as intended
- [x] Tests added to verify new code works
