### PR TITLE
Ignore PLR0917

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ lint.ignore = [
     "PLR0912",  # Too many branches ({branches} > {max_branches})
     "PLR0913",  # Too many arguments to function call ({c_args} > {max_args})
     "PLR0915",  # Too many statements ({statements} > {max_statements})
+    "PLR0917",  # Too many positionsl arguments
     "PLR2004",  # Magic value used in comparison, consider replacing {value} with a constant variable
     "PLW0108", # The fix is not always correct, so this is sometimes a false positive
     "PLW2901",  # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target


### PR DESCRIPTION
## Description:
Ruff 0.16.0 adds a bunch of new rules by default and this one is egregiously dumb

