### PR TITLE
Distinguish rejected credentials from a generic login failure

### DIFF
--- a/blinkpy/api.py
+++ b/blinkpy/api.py
@@ -858,7 +858,7 @@ async def oauth_signin(auth, email, password, csrf_token):
         csrf_token: CSRF token from signin page
 
     Returns:
-        str: "SUCCESS", "2FA_REQUIRED", or None on failure
+        str: "SUCCESS", "2FA_REQUIRED", "INVALID_CREDENTIALS", or None on failure
 
     """
     headers = {
@@ -879,30 +879,42 @@ async def oauth_signin(auth, email, password, csrf_token):
         OAUTH_SIGNIN_URL, headers=headers, data=data, allow_redirects=False
     )
 
-    response_text = ""
-
     if response.status == 412:
         # 2FA required
         return "2FA_REQUIRED"
 
-    if response.status == 202:
-        response_text = await response.text()
-        try:
-            response_json = json.loads(response_text)
-        except json.JSONDecodeError:
-            response_json = {}
-
-        if (
-            response_json.get("tsv_state")
-            or response_json.get("tsv_methods")
-            or response_json.get("next_time_in_secs")
-        ):
-            # 2FA required (new response format with 202 status code)
-            return "2FA_REQUIRED"
-
-    elif response.status in [301, 302, 303, 307, 308]:
+    if response.status in [301, 302, 303, 307, 308]:
         # Success without 2FA
         return "SUCCESS"
+
+    # Blink explains itself in the body on every remaining status, so read it once
+    # and use it both for the log and to tell a rejected password apart from a
+    # server-side failure the caller should retry.
+    try:
+        response_text = await response.text()
+    except UnicodeDecodeError:
+        response_text = ""
+
+    try:
+        response_json = json.loads(response_text)
+    except (json.JSONDecodeError, TypeError):
+        response_json = {}
+
+    if response.status == 202 and (
+        response_json.get("tsv_state")
+        or response_json.get("tsv_methods")
+        or response_json.get("next_time_in_secs")
+    ):
+        # 2FA required (new response format with 202 status code)
+        return "2FA_REQUIRED"
+
+    if response.status == 401:
+        # Retrying cannot fix this, the stored password is no longer the account's.
+        _LOGGER.error(
+            "OAuth signin rejected the credentials: %s",
+            response_json.get("error_description") or response_text[:800],
+        )
+        return "INVALID_CREDENTIALS"
 
     _LOGGER.error(
         "OAuth signin failed: status=%s body=%s",

--- a/blinkpy/auth.py
+++ b/blinkpy/auth.py
@@ -339,7 +339,13 @@ class Auth:
             # Raise exception to let the app handle 2FA prompt
             _LOGGER.info("Two-factor authentication required.")
             raise BlinkTwoFARequiredError
-        elif login_result != "SUCCESS":
+        if login_result == "INVALID_CREDENTIALS":
+            # Raise rather than return False, the same way a 2FA prompt does. Only
+            # new credentials fix this, so the app has to be told to ask for them
+            # instead of retrying a password Blink has already rejected.
+            _LOGGER.error("Login failed: Blink rejected the username or password")
+            raise UnauthorizedError
+        if login_result != "SUCCESS":
             _LOGGER.error("Login failed")
             return False
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -5,7 +5,7 @@ import uuid
 from unittest.mock import Mock, AsyncMock, patch
 from blinkpy.helpers.pkce import generate_pkce_pair
 from blinkpy import api
-from blinkpy.auth import Auth, BlinkTwoFARequiredError
+from blinkpy.auth import Auth, BlinkTwoFARequiredError, UnauthorizedError
 
 
 def test_pkce_generation():
@@ -165,6 +165,61 @@ async def test_oauth_signin_unexpected_status_returns_none():
     result = await api.oauth_signin(auth, "test@example.com", "password", "csrf_token")
 
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_signin_invalid_credentials():
+    """Test oauth_signin reports a rejected password distinctly from other failures."""
+    auth = Mock()
+    auth.session = Mock()
+
+    response = Mock()
+    response.status = 401
+    response.text = AsyncMock(
+        return_value=(
+            '{"error":"unauthorized",'
+            '"error_cause":"invalid_user_credentials",'
+            '"error_description":"Invalid user credentials."}'
+        )
+    )
+    auth.session.post = AsyncMock(return_value=response)
+
+    result = await api.oauth_signin(auth, "test@example.com", "password", "csrf_token")
+
+    assert result == "INVALID_CREDENTIALS"
+
+
+@pytest.mark.asyncio
+async def test_oauth_signin_invalid_credentials_non_json_body():
+    """Test a 401 is still reported as invalid credentials when the body is not JSON."""
+    auth = Mock()
+    auth.session = Mock()
+
+    response = Mock()
+    response.status = 401
+    response.text = AsyncMock(return_value="Unauthorized")
+    auth.session.post = AsyncMock(return_value=response)
+
+    result = await api.oauth_signin(auth, "test@example.com", "password", "csrf_token")
+
+    assert result == "INVALID_CREDENTIALS"
+
+
+@pytest.mark.asyncio
+async def test_oauth_signin_logs_body_on_unexpected_status(caplog):
+    """Test the failure log carries the body Blink sent, not an empty string."""
+    auth = Mock()
+    auth.session = Mock()
+
+    response = Mock()
+    response.status = 500
+    response.text = AsyncMock(return_value="upstream exploded")
+    auth.session.post = AsyncMock(return_value=response)
+
+    result = await api.oauth_signin(auth, "test@example.com", "password", "csrf_token")
+
+    assert result is None
+    assert "upstream exploded" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -329,6 +384,40 @@ async def test_oauth_login_flow_raises_2fa_required():
                 # Verify state was saved
                 assert hasattr(auth, "_oauth_csrf_token")
                 assert hasattr(auth, "_oauth_code_verifier")
+
+
+@pytest.mark.asyncio
+async def test_oauth_login_flow_raises_unauthorized_on_bad_credentials():
+    """Test the login flow raises UnauthorizedError when Blink rejects the password."""
+
+    auth = Auth({"username": "test@example.com", "password": "password"})
+
+    with patch("blinkpy.api.oauth_authorize_request", new=AsyncMock(return_value=True)):
+        with patch(
+            "blinkpy.api.oauth_get_signin_page",
+            new=AsyncMock(return_value="csrf_token"),
+        ):
+            with patch(
+                "blinkpy.api.oauth_signin",
+                new=AsyncMock(return_value="INVALID_CREDENTIALS"),
+            ):
+                with pytest.raises(UnauthorizedError):
+                    await auth._oauth_login_flow()
+
+
+@pytest.mark.asyncio
+async def test_oauth_login_flow_returns_false_on_other_failure():
+    """Test a non-credential signin failure still returns False rather than raising."""
+
+    auth = Auth({"username": "test@example.com", "password": "password"})
+
+    with patch("blinkpy.api.oauth_authorize_request", new=AsyncMock(return_value=True)):
+        with patch(
+            "blinkpy.api.oauth_get_signin_page",
+            new=AsyncMock(return_value="csrf_token"),
+        ):
+            with patch("blinkpy.api.oauth_signin", new=AsyncMock(return_value=None)):
+                assert await auth._oauth_login_flow() is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description

When the account password no longer matches, Blink's OAuth signin step answers 401 with a body that says exactly that:

    {"error":"unauthorized",
     "error_cause":"invalid_user_credentials",
     "error_description":"Invalid user credentials."}

`oauth_signin` read the response body only inside its 202 branch, so on a 401 it logged `OAuth signin failed: status=401 body=` and threw the explanation away. `_oauth_login_flow` then returned False, the same as for any other failure, so a caller cannot tell a rejected password from a transient server error.

Downstream that turns a five second fix into a long diagnosis. In Home Assistant, `Blink.start()` returns False, `available` stays False, and the coordinator raises `ConfigEntryNotReady`, so the integration retries every 10 minutes forever and never shows the re-authenticate prompt. I found this on an instance that had made roughly 1,800 failed logins over 12 days while the log only ever said "Login failed".

### Changes

- `oauth_signin` reads the body once for any status it has not already handled, so the failure log carries Blink's own explanation.
- A 401 returns a new `"INVALID_CREDENTIALS"` result.
- `_oauth_login_flow` raises `UnauthorizedError` for that result, the way it already raises `BlinkTwoFARequiredError` for 2FA. Both mean the app must involve the user rather than retry.

`UnauthorizedError` already propagates through `Blink.start()` untouched, so consumers that handle it get a working re-auth path with no further change. The 412, 202 and redirect paths behave exactly as before.

### Testing

Five tests added to `tests/test_oauth.py` covering the 401 JSON body, a 401 non-JSON body, the body reaching the log on an unexpected status, the new raise, and the unchanged False for other failures. Full suite passes, 254 tests, ruff and black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
