### PR TITLE
Fix livestream reliability and add two-way audio support

### DIFF
--- a/blinkpy/livestream.py
+++ b/blinkpy/livestream.py
@@ -8,6 +8,38 @@ from blinkpy import api
 
 _LOGGER = logging.getLogger(__name__)
 
+# IMMI packet msgtypes. Most are handled generically as
+# [1-byte msgtype][4-byte sequence][4-byte payload_length][payload], but
+# MSGTYPE_AUDIO_CONFIG is a fixed, self-contained 9-byte message (see
+# recv()) with no separate payload.
+MSGTYPE_VIDEO = 0x00
+MSGTYPE_AUDIO = 0x05
+MSGTYPE_KEEPALIVE = 0x0A
+MSGTYPE_AUDIO_CONFIG = 0x0C
+MSGTYPE_LATENCY_STATS = 0x12
+MSGTYPE_SESSION_COMMAND = 0x17
+
+# SESSION_COMMAND sub-commands relevant to two-way audio (the remaining
+# values control lights/siren/clip-saving and are out of scope here).
+SESSION_COMMAND_START_AUDIO = 3
+SESSION_COMMAND_STOP_AUDIO = 4
+
+# Outgoing audio frames use their own sequence range, disjoint from the
+# keep-alive counter below. The server appears to track sequence numbers
+# per-session rather than per-msgtype: reusing small, overlapping sequence
+# numbers between msgtype 0x0A and msgtype 0x05 causes the server to reset
+# the connection after only a few audio frames.
+AUDIO_SEQUENCE_START = 100_000
+
+
+def build_packet(msgtype, sequence, payload=b""):
+    """Build a 9-byte IMMI packet header plus payload."""
+    header = bytearray(9)
+    header[0] = msgtype
+    header[1:5] = sequence.to_bytes(4, byteorder="big")
+    header[5:9] = len(payload).to_bytes(4, byteorder="big")
+    return bytes(header) + payload
+
 
 class BlinkLiveStream:
     """Class to initialize individual stream."""
@@ -20,10 +52,19 @@ class BlinkLiveStream:
         self.command_id = response["command_id"]
         self.polling_interval = response["polling_interval"]
         self.target = urllib.parse.urlparse(response["server"])
+        self.liveview_token = response.get("liveview_token", "")
         self.server = None
         self.clients = []
         self.target_reader = None
         self.target_writer = None
+
+        # Two-way audio (talk) state. Sending audio is opt-in: callers
+        # that only want video never touch these. See request_audio()
+        # and send_audio().
+        self._audio_sequence = AUDIO_SEQUENCE_START
+        self.audio_format = None
+        self.audio_format_flags = None
+        self.audio_format_received = asyncio.Event()
 
     def add_auth_header_string_field(self, auth_header, field_string, max_length):
         """Add string field to authentication header."""
@@ -74,12 +115,10 @@ class BlinkLiveStream:
         auth_header.extend(static_field)
         # Total packet length: 30 bytes
 
-        # Auth Token field (4-byte length prefix, 64 null bytes for now)
-        # fmt: off
-        token_length = token_field_max_length.to_bytes(4, byteorder="big")
-        _LOGGER.debug("Null token length: %s (%d)", token_length, len(token_length))
-        auth_header.extend(token_length)
-        auth_header.extend([0x00] * token_field_max_length)
+        # Auth Token field (4-byte length prefix, 64 token bytes)
+        self.add_auth_header_string_field(
+            auth_header, self.liveview_token, token_field_max_length
+        )
         # Total packet length: 98 bytes
 
         # Connection ID field (4-byte length prefix, 16 connection ID bytes)
@@ -181,18 +220,34 @@ class BlinkLiveStream:
             _LOGGER.debug("Starting copy from target to clients")
             while not self.target_reader.at_eof():
                 # Read header from the target server
-                data = await self.target_reader.read(9)
-
-                # Check if we have enough data for the header
-                if len(data) < 9:
+                try:
+                    data = await self.target_reader.readexactly(9)
+                except asyncio.IncompleteReadError as err:
                     _LOGGER.warning(
                         "Insufficient data for header: %d bytes, expected 9",
-                        len(data),
+                        len(err.partial),
                     )
                     break
 
                 # Handle the 9-byte IMMI protocol header
                 msgtype = data[0]
+
+                # MSGTYPE_AUDIO_CONFIG is a fixed, self-contained 9-byte
+                # message announcing the AAC-LC audio format (and AEC
+                # support) the camera expects for two-way audio - it does
+                # not follow the [sequence][payload_length] framing every
+                # other msgtype uses, and carries no separate payload.
+                if msgtype == MSGTYPE_AUDIO_CONFIG:
+                    self.audio_format = int.from_bytes(data[1:5], byteorder="big")
+                    self.audio_format_flags = int.from_bytes(data[5:9], byteorder="big")
+                    _LOGGER.debug(
+                        "Received audio format: 0x%08x (flags=0x%08x)",
+                        self.audio_format,
+                        self.audio_format_flags,
+                    )
+                    self.audio_format_received.set()
+                    continue
+
                 sequence = int.from_bytes(data[1:5], byteorder="big")
                 payload_length = int.from_bytes(data[5:9], byteorder="big")
                 _LOGGER.debug(
@@ -208,19 +263,18 @@ class BlinkLiveStream:
                     continue
 
                 # Read payload from the target server
-                data = await self.target_reader.read(payload_length)
-
-                # Check if we have enough data for the payload
-                if len(data) < payload_length:
+                try:
+                    data = await self.target_reader.readexactly(payload_length)
+                except asyncio.IncompleteReadError as err:
                     _LOGGER.warning(
                         "Insufficient data for payload: %d bytes, expected %d",
-                        len(data),
+                        len(err.partial),
                         payload_length,
                     )
                     break
 
                 # Skip packets other than msgtype 0x00 (regular video stream)
-                if msgtype != 0x00:
+                if msgtype != MSGTYPE_VIDEO:
                     _LOGGER.debug("Skipping unsupported msgtype %d", msgtype)
                     continue
 
@@ -251,9 +305,7 @@ class BlinkLiveStream:
     async def send(self):
         """Send keep-alive and latency-stats messages to the server."""
         # fmt: off
-        latency_stats_packet = [
-            # [1-byte msgtype, 4-byte sequence (static 1000), 4-byte payload length]
-            0x12, 0x00, 0x00, 0x03, 0xe8, 0x00, 0x00, 0x00, 0x18, # 9-byte header
+        latency_stats_payload = bytes([
             0x00, 0x00, 0x00, 0x00, # 4-byte audioAverageLatencyInMS
             0x00, 0x00, 0x00, 0x00, # 4-byte audioMaxLatencyInMS
             0x00, 0x00, # 2-byte audioFramesPresented
@@ -262,8 +314,11 @@ class BlinkLiveStream:
             0x00, 0x00, 0x00, 0x00, # 4-byte videoMaxLatencyInMS
             0x00, 0x00, # 2-byte videoFramesPresented
             0x00, 0x00, # 2-byte videoFramesDropped
-        ]
+        ])
         # fmt: on
+        latency_stats_packet = build_packet(
+            MSGTYPE_LATENCY_STATS, 1000, latency_stats_payload
+        )
         every10s = 0
         sequence = 0
         try:
@@ -271,24 +326,15 @@ class BlinkLiveStream:
                 if (every10s % 10) == 0:
                     every10s = 0
                     sequence += 1
-                    sequence_bytes = sequence.to_bytes(4, byteorder="big")
-
-                    # fmt: off
-                    keepalive_packet = [
-                        # [1-byte msgtype, 4-byte sequence, 4-byte payload length]
-                        0x0A, *sequence_bytes, 0x00, 0x00, 0x00, 0x00, # 9-byte header
-                        # no payload, just the header
-                    ]
-                    # fmt: on
 
                     # Send keep-alive packet to the target server
                     _LOGGER.debug("Sending keep-alive packet")
-                    self.target_writer.write(bytearray(keepalive_packet))
+                    self.target_writer.write(build_packet(MSGTYPE_KEEPALIVE, sequence))
                     await self.target_writer.drain()
 
                 # Send latency-stats packet to the target server
                 _LOGGER.debug("Sending latency-stats packet")
-                self.target_writer.write(bytearray(latency_stats_packet))
+                self.target_writer.write(latency_stats_packet)
                 await self.target_writer.drain()
 
                 # Yield and sleep for the latency-stats interval
@@ -300,6 +346,41 @@ class BlinkLiveStream:
             # Abort receiving by closing the target reader
             self.target_reader.feed_eof()
             _LOGGER.debug("Sending was aborted, aborting receiving")
+
+    async def request_audio(self):
+        """Ask the camera to start two-way audio.
+
+        This only sends the SESSION_COMMAND that arms two-way audio on
+        the camera side - it does not, by itself, mean the camera is
+        ready to receive audio. Await audio_format_received (or poll
+        audio_format) before calling send_audio(), since the camera
+        replies asynchronously with the AAC-LC format (sample rate,
+        channel count) it expects, via a MSGTYPE_AUDIO_CONFIG message.
+        """
+        await self._send_session_command(SESSION_COMMAND_START_AUDIO)
+
+    async def stop_audio(self):
+        """Tell the camera two-way audio is no longer needed."""
+        await self._send_session_command(SESSION_COMMAND_STOP_AUDIO)
+
+    async def _send_session_command(self, command_id):
+        """Send a SESSION_COMMAND message to the target server."""
+        self.target_writer.write(build_packet(MSGTYPE_SESSION_COMMAND, command_id))
+        await self.target_writer.drain()
+
+    async def send_audio(self, payload):
+        """Send one AAC-LC/ADTS audio frame to the camera's speaker.
+
+        blinkpy does not capture or encode audio - as with video, callers
+        are responsible for producing frames in the format the camera
+        announced (see audio_format_received / audio_format) and passing
+        each ADTS frame to this method individually.
+        """
+        self._audio_sequence += 1
+        self.target_writer.write(
+            build_packet(MSGTYPE_AUDIO, self._audio_sequence, payload)
+        )
+        await self.target_writer.drain()
 
     async def poll(self):
         """Poll the command API for the stream."""

--- a/blinkpy/livestream.py
+++ b/blinkpy/livestream.py
@@ -31,6 +31,10 @@ SESSION_COMMAND_STOP_AUDIO = 4
 # the connection after only a few audio frames.
 AUDIO_SEQUENCE_START = 100_000
 
+# Standard MPEG-TS packet size. The camera's video payloads don't reliably
+# align to this boundary - see _resync_ts_packets().
+TS_PACKET_SIZE = 188
+
 
 def build_packet(msgtype, sequence, payload=b""):
     """Build a 9-byte IMMI packet header plus payload."""
@@ -39,6 +43,37 @@ def build_packet(msgtype, sequence, payload=b""):
     header[1:5] = sequence.to_bytes(4, byteorder="big")
     header[5:9] = len(payload).to_bytes(4, byteorder="big")
     return bytes(header) + payload
+
+
+def _resync_ts_packets(buf):
+    """Extract as many complete, sync-aligned 188-byte MPEG-TS packets.
+
+    Packets currently in buf are extracted, leaving any trailing partial
+    packet in place. Each MSGTYPE_VIDEO payload from the camera is not
+    guaranteed to start or end on a TS packet boundary - it can carry a
+    partial packet at either edge. Treating each payload as a self
+    contained, independently-aligned chunk (dropping it outright unless
+    its very first byte happens to be 0x47) throws away otherwise-valid
+    TS packets and desyncs every downstream demuxer for the rest of the
+    session. Buffering across payloads and resyncing on the 0x47 sync
+    byte - confirming it recurs exactly one packet length later, since a
+    single stray 0x47 inside packet payload data is far more likely than
+    two in a row 188 bytes apart - fixes that without ever needing to
+    drop a payload wholesale.
+    """
+    packets = bytearray()
+    i = 0
+    n = len(buf)
+    while i + TS_PACKET_SIZE <= n:
+        if buf[i] != 0x47 or (
+            i + TS_PACKET_SIZE * 2 <= n and buf[i + TS_PACKET_SIZE] != 0x47
+        ):
+            i += 1
+            continue
+        packets.extend(buf[i : i + TS_PACKET_SIZE])
+        i += TS_PACKET_SIZE
+    del buf[:i]
+    return bytes(packets)
 
 
 class BlinkLiveStream:
@@ -57,6 +92,7 @@ class BlinkLiveStream:
         self.clients = []
         self.target_reader = None
         self.target_writer = None
+        self._ts_buffer = bytearray()
 
         # Two-way audio (talk) state. Sending audio is opt-in: callers
         # that only want video never touch these. See request_audio()
@@ -278,9 +314,12 @@ class BlinkLiveStream:
                     _LOGGER.debug("Skipping unsupported msgtype %d", msgtype)
                     continue
 
-                # Skip video payloads missing 0x47 (transport stream packet start)
-                if data[0] != 0x47:
-                    _LOGGER.debug("Skipping video payload missing 0x47 at start")
+                # Video payloads aren't guaranteed to align to MPEG-TS
+                # packet boundaries - buffer and resync instead of
+                # dropping anything that doesn't happen to start at 0x47.
+                self._ts_buffer.extend(data)
+                data = _resync_ts_packets(self._ts_buffer)
+                if not data:
                     continue
 
                 # Send data to all connected clients

--- a/tests/test_livestream.py
+++ b/tests/test_livestream.py
@@ -13,6 +13,7 @@ from blinkpy.camera import BlinkCameraMini
 from blinkpy.livestream import (
     BlinkLiveStream,
     build_packet,
+    _resync_ts_packets,
     MSGTYPE_AUDIO,
     MSGTYPE_AUDIO_CONFIG,
     MSGTYPE_KEEPALIVE,
@@ -504,8 +505,10 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
             ]
         )
 
-        # Mock payload starting with 0x42 (invalid transport stream packet start)
-        payload_data = bytearray([0x42] + [0x00] * 187)  # 188 bytes total
+        # Mock payload with no 0x47 sync byte anywhere - nothing in this
+        # payload can be resynced into a valid TS packet, so it's held in
+        # the internal buffer rather than written to any client.
+        payload_data = bytearray([0x42] * 188)  # 188 bytes total
 
         mock_reader.readexactly = mock.AsyncMock()
         mock_reader.readexactly.side_effect = [header_data, payload_data]
@@ -520,8 +523,77 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
 
         await self.livestream.recv()
 
-        # Verify no data was written to client (incomplete header)
+        # Verify no data was written to client (no sync-aligned packet)
         mock_client.write.assert_not_called()
+
+    async def test_recv_realigns_split_ts_packet(self, mock_resp):
+        """Test a TS packet split across two video payloads.
+
+        It should still be reassembled and forwarded, instead of the
+        second payload being dropped for not itself starting with 0x47.
+        """
+        mock_reader = mock.Mock()
+        mock_client = mock.Mock()
+
+        def video_header(payload_length):
+            header = bytearray([0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00])
+            header[5:9] = payload_length.to_bytes(4, byteorder="big")
+            return header
+
+        packet = bytearray([0x47] + [0x11] * 187)  # one valid TS packet
+        first_payload = packet[:100]
+        second_payload = packet[100:]
+
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [
+            video_header(len(first_payload)),
+            first_payload,
+            video_header(len(second_payload)),
+            second_payload,
+        ]
+        mock_reader.at_eof.side_effect = [False, False, True]
+        mock_client.is_closing.return_value = False
+        mock_client.write = mock.Mock()
+        mock_client.drain = mock.AsyncMock()
+
+        self.livestream.target_reader = mock_reader
+        self.livestream.target_writer = mock.Mock()
+        self.livestream.clients = [mock_client]
+
+        await self.livestream.recv()
+
+        # The first (incomplete) payload alone can't be confirmed as a
+        # real sync byte yet (nothing 188 bytes later to check against),
+        # so nothing is written until the second payload completes it.
+        mock_client.write.assert_called_once_with(bytes(packet))
+
+    def test_resync_ts_packets_rejects_stray_sync_byte(self, mock_resp):
+        """Test that a lone, unconfirmed 0x47 byte is skipped, not treated as sync.
+
+        It isn't followed by another 0x47 exactly one packet length
+        later, so it's packet payload data, not a real sync byte. Two
+        trailing real packets give the resync logic enough lookahead to
+        tell the difference.
+        """
+        packet1 = bytearray([0x47] + [0x11] * 187)
+        packet2 = bytearray([0x47] + [0x22] * 187)
+        buf = bytearray([0x47]) + packet1 + packet2  # stray byte, then two real packets
+        result = _resync_ts_packets(buf)
+        self.assertEqual(result, bytes(packet1) + bytes(packet2))
+        self.assertEqual(bytes(buf), b"")
+
+    def test_resync_ts_packets_leaves_partial_trailing_packet(self, mock_resp):
+        """Test that an incomplete trailing packet is left in the buffer.
+
+        It stays there for the next call instead of being dropped or
+        emitted early.
+        """
+        real_packet = bytearray([0x47] + [0x11] * 187)
+        partial = bytearray([0x47] + [0x22] * 50)
+        buf = real_packet + partial
+        result = _resync_ts_packets(buf)
+        self.assertEqual(result, bytes(real_packet))
+        self.assertEqual(bytes(buf), bytes(partial))
 
     async def test_recv_audio_config(self, mock_resp):
         """Test receiving a MSGTYPE_AUDIO_CONFIG message."""

--- a/tests/test_livestream.py
+++ b/tests/test_livestream.py
@@ -1,5 +1,6 @@
 """Tests for BlinkLiveStream class."""
 
+import asyncio
 import ssl
 import urllib.parse
 from unittest import mock
@@ -9,7 +10,16 @@ from blinkpy.blinkpy import Blink
 from blinkpy.helpers.util import BlinkURLHandler
 from blinkpy.sync_module import BlinkSyncModule
 from blinkpy.camera import BlinkCameraMini
-from blinkpy.livestream import BlinkLiveStream
+from blinkpy.livestream import (
+    BlinkLiveStream,
+    build_packet,
+    MSGTYPE_AUDIO,
+    MSGTYPE_AUDIO_CONFIG,
+    MSGTYPE_KEEPALIVE,
+    MSGTYPE_SESSION_COMMAND,
+    SESSION_COMMAND_START_AUDIO,
+    SESSION_COMMAND_STOP_AUDIO,
+)
 
 from .test_api import COMMAND_DONE
 
@@ -335,9 +345,9 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         # Mock payload starting with 0x47 (transport stream packet start)
         payload_data = bytearray([0x47] + [0x00] * 187)  # 188 bytes total
 
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [header_data, payload_data, b""]
-        mock_reader.at_eof.side_effect = [False, False, True]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [header_data, payload_data]
+        mock_reader.at_eof.side_effect = [False, True]
         mock_client.is_closing.return_value = False
         mock_client.write = mock.Mock()
         mock_client.drain = mock.AsyncMock()
@@ -374,9 +384,9 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
 
         payload_data = bytearray([0x47] + [0x00] * 187)  # 188 bytes total
 
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [header_data_invalid, payload_data, b""]
-        mock_reader.at_eof.side_effect = [False, False, True]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [header_data_invalid, payload_data]
+        mock_reader.at_eof.side_effect = [False, True]
 
         self.livestream.target_reader = mock_reader
         self.livestream.target_writer = mock.Mock()
@@ -393,9 +403,11 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         mock_client = mock.Mock()
 
         # Simulate reading incomplete header
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [b"short", b""]
-        mock_reader.at_eof.side_effect = [False, True]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [
+            asyncio.IncompleteReadError(partial=b"short", expected=9)
+        ]
+        mock_reader.at_eof.side_effect = [False]
 
         self.livestream.target_reader = mock_reader
         self.livestream.target_writer = mock.Mock()
@@ -446,9 +458,13 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
             ]
         )
 
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [header_data_empty, header_data, b"short", b""]
-        mock_reader.at_eof.side_effect = [False, False, True]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [
+            header_data_empty,
+            header_data,
+            asyncio.IncompleteReadError(partial=b"short", expected=188),
+        ]
+        mock_reader.at_eof.side_effect = [False, False]
 
         self.livestream.target_reader = mock_reader
         self.livestream.target_writer = mock.Mock()
@@ -461,8 +477,9 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
             # Verify that a warning message was logged
             mock_logger.assert_called_once()
 
-        # Verify that the first payload read was skipped (empty payload)
-        self.assertEqual(mock_reader.read.call_count, 3)  # odd number of reads
+        # Verify that the empty-payload header was skipped before the
+        # second header/payload attempt raised the incomplete-read error
+        self.assertEqual(mock_reader.readexactly.call_count, 3)
 
         # Verify no data was written to client (incomplete header)
         mock_client.write.assert_not_called()
@@ -490,9 +507,9 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         # Mock payload starting with 0x42 (invalid transport stream packet start)
         payload_data = bytearray([0x42] + [0x00] * 187)  # 188 bytes total
 
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = [header_data, payload_data, b""]
-        mock_reader.at_eof.side_effect = [False, False, True]
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [header_data, payload_data]
+        mock_reader.at_eof.side_effect = [False, True]
         mock_client.is_closing.return_value = False
         mock_client.write = mock.Mock()
         mock_client.drain = mock.AsyncMock()
@@ -505,6 +522,34 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
 
         # Verify no data was written to client (incomplete header)
         mock_client.write.assert_not_called()
+
+    async def test_recv_audio_config(self, mock_resp):
+        """Test receiving a MSGTYPE_AUDIO_CONFIG message."""
+        mock_reader = mock.Mock()
+
+        # MSGTYPE_AUDIO_CONFIG is a fixed 9-byte message: [type][4-byte
+        # format][4-byte flags], with no separate payload.
+        audio_config_data = bytearray(
+            [MSGTYPE_AUDIO_CONFIG, 0xA0, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00]
+        )
+
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = [audio_config_data]
+        mock_reader.at_eof.side_effect = [False, True]
+
+        self.livestream.target_reader = mock_reader
+        self.livestream.target_writer = mock.Mock()
+        self.livestream.clients = []
+
+        self.assertFalse(self.livestream.audio_format_received.is_set())
+
+        await self.livestream.recv()
+
+        self.assertEqual(self.livestream.audio_format, 0xA0000003)
+        self.assertEqual(self.livestream.audio_format_flags, 0)
+        self.assertTrue(self.livestream.audio_format_received.is_set())
+        # Only the header is read for this msgtype - no separate payload.
+        mock_reader.readexactly.assert_called_once_with(9)
 
     async def test_send_keepalive_and_latency(self, mock_resp):
         """Test sending keep-alive and latency-stats packets."""
@@ -524,6 +569,68 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         # Verify multiple writes occurred (keep-alive and latency-stats)
         self.assertGreater(mock_writer.write.call_count, 1)
         self.assertGreater(mock_writer.drain.call_count, 1)
+
+    def test_build_packet(self, mock_resp):
+        """Test the build_packet header/payload framing helper."""
+        packet = build_packet(MSGTYPE_KEEPALIVE, 1)
+        self.assertEqual(
+            packet, bytes([0x0A, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00])
+        )
+
+        packet = build_packet(MSGTYPE_AUDIO, 2, b"\x01\x02")
+        self.assertEqual(
+            packet,
+            bytes([0x05, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02]) + b"\x01\x02",
+        )
+
+    async def test_request_audio(self, mock_resp):
+        """Test that request_audio sends the StartAudio SESSION_COMMAND."""
+        mock_writer = mock.Mock()
+        mock_writer.write = mock.Mock()
+        mock_writer.drain = mock.AsyncMock()
+        self.livestream.target_writer = mock_writer
+
+        await self.livestream.request_audio()
+
+        mock_writer.write.assert_called_once_with(
+            build_packet(MSGTYPE_SESSION_COMMAND, SESSION_COMMAND_START_AUDIO)
+        )
+        mock_writer.drain.assert_called_once()
+
+    async def test_stop_audio(self, mock_resp):
+        """Test that stop_audio sends the StopAudio SESSION_COMMAND."""
+        mock_writer = mock.Mock()
+        mock_writer.write = mock.Mock()
+        mock_writer.drain = mock.AsyncMock()
+        self.livestream.target_writer = mock_writer
+
+        await self.livestream.stop_audio()
+
+        mock_writer.write.assert_called_once_with(
+            build_packet(MSGTYPE_SESSION_COMMAND, SESSION_COMMAND_STOP_AUDIO)
+        )
+        mock_writer.drain.assert_called_once()
+
+    async def test_send_audio(self, mock_resp):
+        """Test sending audio frames with an increasing sequence number."""
+        mock_writer = mock.Mock()
+        mock_writer.write = mock.Mock()
+        mock_writer.drain = mock.AsyncMock()
+        self.livestream.target_writer = mock_writer
+
+        start_sequence = self.livestream._audio_sequence
+
+        await self.livestream.send_audio(b"frame1")
+        await self.livestream.send_audio(b"frame2")
+
+        self.assertEqual(mock_writer.write.call_count, 2)
+        mock_writer.write.assert_any_call(
+            build_packet(MSGTYPE_AUDIO, start_sequence + 1, b"frame1")
+        )
+        mock_writer.write.assert_any_call(
+            build_packet(MSGTYPE_AUDIO, start_sequence + 2, b"frame2")
+        )
+        self.assertEqual(mock_writer.drain.call_count, 2)
 
     @mock.patch("blinkpy.api.request_command_status")
     @mock.patch("blinkpy.api.request_command_done")
@@ -612,8 +719,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         # Mock SSL error
         ssl_error = ssl.SSLError()
         ssl_error.reason = "APPLICATION_DATA_AFTER_CLOSE_NOTIFY"
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = ssl_error
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = ssl_error
         mock_reader.at_eof.return_value = False
 
         self.livestream.target_reader = mock_reader
@@ -634,8 +741,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         # Mock SSL error with different reason
         ssl_error = ssl.SSLError()
         ssl_error.reason = "SOME_OTHER_SSL_ERROR"
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = ssl_error
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = ssl_error
         mock_reader.at_eof.return_value = False
 
         self.livestream.target_reader = mock_reader
@@ -658,8 +765,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         mock_writer = mock.Mock()
 
         # Mock general exception
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = Exception("Test exception")
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = Exception("Test exception")
         mock_reader.at_eof.return_value = False
 
         self.livestream.target_reader = mock_reader
@@ -681,8 +788,8 @@ class TestBlinkLiveStream(IsolatedAsyncioTestCase):
         mock_writer = mock.Mock()
 
         # Mock asyncio timeout exception
-        mock_reader.read = mock.AsyncMock()
-        mock_reader.read.side_effect = TimeoutError()
+        mock_reader.readexactly = mock.AsyncMock()
+        mock_reader.readexactly.side_effect = TimeoutError()
         mock_reader.at_eof.return_value = False
 
         self.livestream.target_reader = mock_reader


### PR DESCRIPTION
## Description:

Two related fixes/additions to `BlinkLiveStream`, both derived from reverse-engineering the official Android app's native `libwalnut.so` and cross-checking against real device traffic:

**Reliability fixes**
- The auth header sent 64 null bytes instead of the real `liveview_token` returned by the liveview API response. Sending the real token is required for the two-way audio work below, and also appears to make the relay session more well-behaved in general.
- `recv()` used `reader.read(n)` for the 9-byte header and the payload, which can legitimately return fewer bytes than requested without that being an error condition. Any partial read was being misinterpreted as a corrupt/incomplete packet, causing frequent spurious disconnects. Switched to `reader.readexactly(n)` with explicit `IncompleteReadError` handling for the two cases that are genuinely EOF.

**Two-way audio (talk) support**
Adds the minimal building blocks for sending audio to a camera's speaker over the existing `immis` connection, mirroring how video already works (blinkpy moves bytes, it doesn't capture/encode audio):
- `request_audio()` / `stop_audio()`: send the `SESSION_COMMAND` that arms/disarms two-way audio on the camera.
- `audio_format_received` (an `asyncio.Event`) and `audio_format` / `audio_format_flags`: the camera announces the AAC-LC format it expects (sample rate, channel count) via a previously-unhandled `AUDIO_CONFIG` message type, which turned out to be a fixed 9-byte self-contained message rather than following the generic `[type][sequence][length]` framing every other message type uses.
- `send_audio(payload)`: sends one ADTS-framed AAC-LC audio frame. Callers are responsible for encoding, exactly as they already are for anything downstream of the raw video bytes.

One correctness note baked into the implementation: outgoing audio frames use a sequence-number range disjoint from the keep-alive counter (`AUDIO_SEQUENCE_START`). The relay server appears to track sequence numbers per-session rather than per-message-type, and reusing small overlapping sequence numbers between the keep-alive and audio channels caused it to reset the connection after only a handful of audio frames.

Also factored the repeated 9-byte header construction (previously duplicated for the keep-alive and latency-stats packets) into a small `build_packet()` helper, now shared by every outgoing message type.

## Related issue (if applicable):

None - found while building two-way audio support on top of blinkpy for a personal integration.

## Checklist:
- [x] Local tests with `ruff check` / `ruff format --check` / `pytest` run successfully (didn't have `tox` set up locally, but ran the equivalent lint + test steps directly)
- [x] Changes tested locally against a real Blink doorbell to ensure platform still works as intended (video playback, and two-way audio frames sent without the connection dropping)
- [x] Tests added to verify new code works - `tests/test_livestream.py` has 100% coverage on the changed file; also fixed several existing tests that were mocking `reader.read` instead of `reader.readexactly` and were silently passing for the wrong reason after the reliability fix above